### PR TITLE
Add dependency-constraints plug-in to allow loading version constraints

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -7,3 +7,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - managed-credentials plug-in which provides a DSL for re-usable loaded credentials from multiple sources
+- dependency-constraints plug-in which provides a DSL for applying dependency version constraints to all configurations in bulk from an external file

--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
     compile 'org.starchartlabs.alloy:alloy-core:0.4.1'
     
     testCompile gradleTestKit()
+    testCompile 'org.mockito:mockito-core:2.25.0'
     testCompile 'org.testng:testng:6.14.3'
 }
 

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ConstraintFile.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ConstraintFile.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+/**
+ * Represents a file which specifies version constraints for dependencies
+ *
+ * <p>
+ * Processed files may have lines which are blank, start with '#' (comments), and which contain 'group:artifact:version'
+ * to apply constraints
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class ConstraintFile {
+
+    private final Path path;
+
+    private Set<String> loaded;
+
+    /**
+     * @param path
+     *            Path to the file to process
+     * @since 0.1.0
+     */
+    public ConstraintFile(Path path) {
+        this.path = Objects.requireNonNull(path);
+        this.loaded = null;
+    }
+
+    /**
+     * Parses the represented file, providing the specified dependency constraints
+     *
+     * @return A set of the dependency GAV's to constrain
+     * @throws IOException
+     *             If there is an error reading the file
+     * @since 0.1.0
+     */
+    public Set<String> getDependencyNotations() throws IOException {
+        if (loaded == null) {
+            loaded = Files.lines(path)
+                    .map(String::trim)
+                    .filter(line -> !line.isEmpty())
+                    .filter(line -> !isComment(line))
+                    .collect(Collectors.toSet());
+        }
+
+        return loaded;
+    }
+
+    /**
+     * @param line
+     *            Line to analyze
+     * @return True if the line provided is a comment line, false otherwise
+     */
+    private boolean isComment(String line) {
+        return line.startsWith("#");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(path);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof ConstraintFile) {
+            ConstraintFile compare = (ConstraintFile) obj;
+
+            result = Objects.equals(path, compare.path);
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("path", path)
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/DependencyConstraints.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/DependencyConstraints.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
+import org.gradle.internal.impldep.aQute.lib.strings.Strings;
+import org.starchartlabs.alloy.core.Preconditions;
+
+/**
+ * Represents domain-specific language applied to Gradle build files
+ *
+ * <p>
+ * This DSL allows reading dependency constraints from an external file and application of them to all configurations
+ * within a project
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class DependencyConstraints {
+
+    private static final Map<Path, ConstraintFile> loadedFileCache = new HashMap<>();
+
+    private final Project project;
+
+    /**
+     * @param project
+     *            The project the DSL is being added to
+     * @since 0.1.0
+     */
+    public DependencyConstraints(Project project) {
+        this.project = Objects.requireNonNull(project);
+    }
+
+    /**
+     * Applies dependency constraints to all configurations from an external file
+     *
+     * <p>
+     * Files are expected to specific a single GAV (group:artifact:version) per line
+     *
+     * @param file
+     *            External files to read constraints from
+     * @return This constraints object
+     * @throws IOException
+     *             If there is an error reading the file
+     * @since 0.1.0
+     */
+    public DependencyConstraints file(File file) throws IOException {
+        Objects.requireNonNull(file);
+        Preconditions.checkArgument(file.exists(),
+                () -> Strings.format("Constraint file at %s does not exist", file.toPath().toString()));
+
+        Set<String> constraints = getArtifactConstraints(file);
+
+        project.getConfigurations().all(configuration -> {
+            constraints.forEach(gav -> {
+                project.getDependencies().getConstraints()
+                .add(configuration.getName(), gav, this::configureConstraint);
+
+                project.getLogger().info("Applied {} dependency constraint: {}", configuration, gav);
+            });
+        });
+
+        return this;
+    }
+
+    /**
+     * Applies post-creation configuration to a generated dependency constraint
+     *
+     * <p>
+     * This includes forcing the constraint on transitive dependencies, if possible via the supplied implementation
+     *
+     * @param constraint
+     *            The constraint to configure
+     */
+    private void configureConstraint(DependencyConstraint constraint) {
+        // This is because the force flag is not part of public API - an issue has been filed at
+        // https://github.com/gradle/gradle/issues/9934 for Gradle to consider changing this
+        if (constraint instanceof DependencyConstraintInternal) {
+            ((DependencyConstraintInternal) constraint).setForce(true);
+
+            project.getLogger().debug("Forced constraint {}", constraint.getName());
+        } else {
+            project.getLogger().debug("Unable to force constraint {}", constraint.getName());
+        }
+    }
+
+    /**
+     * Loads constraints from the provided file, using previously read and cached values if available
+     *
+     * @param file
+     *            The file to read values from
+     * @return The dependency constraints to apply
+     * @throws IOException
+     *             If there is an error loading the file
+     */
+    private synchronized Set<String> getArtifactConstraints(File file) throws IOException {
+        Objects.requireNonNull(file);
+
+        Path key = file.toPath();
+
+        if (!loadedFileCache.containsKey(key)) {
+            loadedFileCache.put(key, new ConstraintFile(key));
+        }
+
+        return loadedFileCache.get(key).getDependencyNotations();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/DependencyConstraintsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/DependencyConstraintsPlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.starchartlabs.flare.plugins.model.DependencyConstraints;
+
+/**
+ * Configuration plug-in that adds structures for loading dependency version constraints and applying them to all
+ * configurations
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class DependencyConstraintsPlugin implements Plugin<Project> {
+
+    private static final String CONSTRAINTS_DSL_EXTENSION = "dependencyConstraints";
+
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().add(CONSTRAINTS_DSL_EXTENSION, new DependencyConstraints(project));
+    }
+
+}

--- a/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.dependency-constraints.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.dependency-constraints.properties
@@ -1,0 +1,1 @@
+implementation-class=org.starchartlabs.flare.plugins.plugin.DependencyConstraintsPlugin

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ConstraintFileTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ConstraintFileTest.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import org.starchartlabs.flare.plugins.model.ConstraintFile;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConstraintFileTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullPath() throws Exception {
+        new ConstraintFile(null);
+    }
+
+    @Test
+    public void getDependencyNotationsNoDiscardedLines() throws Exception {
+        List<String> lines = new ArrayList<>();
+        lines.add("group1:artifact1:1.0");
+        lines.add("group2:artifact2:2.0");
+        lines.add("group3:artifact3:3.0");
+
+        Path path = Files.createTempFile("constraintFileTest", "no-discards");
+
+        Files.write(path, lines);
+
+        ConstraintFile file = new ConstraintFile(path);
+
+        Set<String> result = file.getDependencyNotations();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertTrue(result.contains("group1:artifact1:1.0"));
+        Assert.assertTrue(result.contains("group2:artifact2:2.0"));
+        Assert.assertTrue(result.contains("group3:artifact3:3.0"));
+    }
+
+    @Test
+    public void getDependencyNotationsCommentsBlanksAndWhitespace() throws Exception {
+        List<String> lines = new ArrayList<>();
+        lines.add("group1:artifact1:1.0");
+        lines.add("");
+        lines.add("# Comment");
+        lines.add("group2:artifact2:2.0 ");
+        lines.add(" # Comment");
+        lines.add(" group3:artifact3:3.0");
+
+        Path path = Files.createTempFile("constraintFileTest", "no-discards");
+
+        Files.write(path, lines);
+
+        ConstraintFile file = new ConstraintFile(path);
+
+        Set<String> result = file.getDependencyNotations();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertTrue(result.contains("group1:artifact1:1.0"));
+        Assert.assertTrue(result.contains("group2:artifact2:2.0"));
+        Assert.assertTrue(result.contains("group3:artifact3:3.0"));
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        ConstraintFile result1 = new ConstraintFile(Paths.get("path"));
+        ConstraintFile result2 = new ConstraintFile(Paths.get("path"));
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        ConstraintFile result = new ConstraintFile(Paths.get("path"));
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        ConstraintFile result = new ConstraintFile(Paths.get("path"));
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        ConstraintFile result = new ConstraintFile(Paths.get("path"));
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        ConstraintFile result1 = new ConstraintFile(Paths.get("path1"));
+        ConstraintFile result2 = new ConstraintFile(Paths.get("path2"));
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        ConstraintFile result1 = new ConstraintFile(Paths.get("path"));
+        ConstraintFile result2 = new ConstraintFile(Paths.get("path"));
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Path path = Paths.get("path");
+        ConstraintFile obj = new ConstraintFile(path);
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("path=" + path.toString()));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/DependencyConstraintsTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/DependencyConstraintsTest.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.api.artifacts.Configuration;
+import org.gradle.api.artifacts.ConfigurationContainer;
+import org.gradle.api.artifacts.DependencyConstraint;
+import org.gradle.api.artifacts.dsl.DependencyConstraintHandler;
+import org.gradle.api.artifacts.dsl.DependencyHandler;
+import org.gradle.api.internal.artifacts.dependencies.DependencyConstraintInternal;
+import org.gradle.api.logging.Logger;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.starchartlabs.flare.plugins.model.DependencyConstraints;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class DependencyConstraintsTest {
+
+    private File file;
+
+    @BeforeClass
+    public void setupFile() throws Exception {
+        List<String> lines = new ArrayList<>();
+        lines.add("group1:artifact1:1.0");
+        lines.add("group2:artifact2:2.0");
+        lines.add("group3:artifact3:3.0");
+
+        Path path = Files.createTempFile("constraintFileTest", "no-discards");
+
+        Files.write(path, lines);
+
+        file = path.toFile();
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullProject() throws Exception {
+        new DependencyConstraints(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void fileNullFile() throws Exception {
+        Project project = Mockito.mock(Project.class);
+
+        DependencyConstraints dependencyConstraints = new DependencyConstraints(project);
+
+        dependencyConstraints.file(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void fileDoesntExist() throws Exception {
+        Project project = Mockito.mock(Project.class);
+
+        DependencyConstraints dependencyConstraints = new DependencyConstraints(project);
+
+        dependencyConstraints.file(Paths.get("does-not-exist").toFile());
+    }
+
+    // Suppressing unchecked as its a product of mocking generics
+    @Test
+    @SuppressWarnings("unchecked")
+    public void fileUnforcibleConstraints() throws Exception {
+        Project project = Mockito.mock(Project.class);
+        Logger logger = Mockito.mock(Logger.class);
+        ConfigurationContainer configurationContainer = Mockito.mock(ConfigurationContainer.class);
+        Configuration configuration = Mockito.mock(Configuration.class);
+        DependencyHandler dependencyHandler = Mockito.mock(DependencyHandler.class);
+        DependencyConstraintHandler dependencyConstraintHandler = Mockito.mock(DependencyConstraintHandler.class);
+        DependencyConstraint constraint = Mockito.mock(DependencyConstraint.class);
+
+        Mockito.when(project.getLogger()).thenReturn(logger);
+        Mockito.when(project.getConfigurations()).thenReturn(configurationContainer);
+        Mockito.when(configuration.getName()).thenReturn("configName");
+        Mockito.when(project.getDependencies()).thenReturn(dependencyHandler);
+        Mockito.when(dependencyHandler.getConstraints()).thenReturn(dependencyConstraintHandler);
+        Mockito.when(constraint.getName()).thenReturn("constraintName");
+
+        ArgumentCaptor<Action<Configuration>> configurationActionCapture = ArgumentCaptor.forClass(Action.class);
+        ArgumentCaptor<Action<DependencyConstraint>> constraintActionsCapture = ArgumentCaptor.forClass(Action.class);
+
+        DependencyConstraints dependencyConstraints = new DependencyConstraints(project);
+
+        dependencyConstraints.file(file);
+
+        Mockito.verify(project).getConfigurations();
+        Mockito.verify(configurationContainer).all(configurationActionCapture.capture());
+
+        List<Action<Configuration>> configurationActions = configurationActionCapture.getAllValues();
+
+        Assert.assertEquals(configurationActions.size(), 1);
+        configurationActions.get(0).execute(configuration);
+
+        Mockito.verify(project, Mockito.times(3)).getDependencies();
+        Mockito.verify(dependencyHandler, Mockito.times(3)).getConstraints();
+        Mockito.verify(configuration, Mockito.times(3)).getName();
+        Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group1:artifact1:1.0");
+        Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group2:artifact2:2.0");
+        Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group3:artifact3:3.0");
+
+        Mockito.verify(dependencyConstraintHandler).add(Mockito.eq("configName"), Mockito.eq("group1:artifact1:1.0"),
+                constraintActionsCapture.capture());
+        Mockito.verify(dependencyConstraintHandler).add(Mockito.eq("configName"), Mockito.eq("group2:artifact2:2.0"),
+                constraintActionsCapture.capture());
+        Mockito.verify(dependencyConstraintHandler).add(Mockito.eq("configName"), Mockito.eq("group3:artifact3:3.0"),
+                constraintActionsCapture.capture());
+
+        List<Action<DependencyConstraint>> constraintActions = constraintActionsCapture.getAllValues();
+
+        Assert.assertEquals(constraintActions.size(), 3);
+
+        // Verify one of the actions
+        constraintActions.get(0).execute(constraint);
+
+        Mockito.verify(logger).debug("Unable to force constraint {}", constraint.getName());
+    }
+
+    // Suppressing unchecked as its a product of mocking generics
+    @Test
+    @SuppressWarnings("unchecked")
+    public void fileForcibleContraints() throws Exception {
+        Project project = Mockito.mock(Project.class);
+        Logger logger = Mockito.mock(Logger.class);
+        ConfigurationContainer configurationContainer = Mockito.mock(ConfigurationContainer.class);
+        Configuration configuration = Mockito.mock(Configuration.class);
+        DependencyHandler dependencyHandler = Mockito.mock(DependencyHandler.class);
+        DependencyConstraintHandler dependencyConstraintHandler = Mockito.mock(DependencyConstraintHandler.class);
+        DependencyConstraintInternal constraint = Mockito.mock(DependencyConstraintInternal.class);
+
+        Mockito.when(project.getLogger()).thenReturn(logger);
+        Mockito.when(project.getConfigurations()).thenReturn(configurationContainer);
+        Mockito.when(configuration.getName()).thenReturn("configName");
+        Mockito.when(project.getDependencies()).thenReturn(dependencyHandler);
+        Mockito.when(dependencyHandler.getConstraints()).thenReturn(dependencyConstraintHandler);
+        Mockito.when(constraint.getName()).thenReturn("constraintName");
+
+        ArgumentCaptor<Action<Configuration>> configurationActionCapture = ArgumentCaptor.forClass(Action.class);
+        ArgumentCaptor<Action<DependencyConstraint>> constraintActionsCapture = ArgumentCaptor.forClass(Action.class);
+
+        DependencyConstraints dependencyConstraints = new DependencyConstraints(project);
+
+        dependencyConstraints.file(file);
+
+        Mockito.verify(project).getConfigurations();
+        Mockito.verify(configurationContainer).all(configurationActionCapture.capture());
+
+        List<Action<Configuration>> configurationActions = configurationActionCapture.getAllValues();
+
+        Assert.assertEquals(configurationActions.size(), 1);
+        configurationActions.get(0).execute(configuration);
+
+        Mockito.verify(project, Mockito.times(3)).getDependencies();
+        Mockito.verify(dependencyHandler, Mockito.times(3)).getConstraints();
+        Mockito.verify(configuration, Mockito.times(3)).getName();
+        Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group1:artifact1:1.0");
+        Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group2:artifact2:2.0");
+        Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group3:artifact3:3.0");
+
+        Mockito.verify(dependencyConstraintHandler).add(Mockito.eq("configName"), Mockito.eq("group1:artifact1:1.0"),
+                constraintActionsCapture.capture());
+        Mockito.verify(dependencyConstraintHandler).add(Mockito.eq("configName"), Mockito.eq("group2:artifact2:2.0"),
+                constraintActionsCapture.capture());
+        Mockito.verify(dependencyConstraintHandler).add(Mockito.eq("configName"), Mockito.eq("group3:artifact3:3.0"),
+                constraintActionsCapture.capture());
+
+        List<Action<DependencyConstraint>> constraintActions = constraintActionsCapture.getAllValues();
+
+        Assert.assertEquals(constraintActions.size(), 3);
+
+        // Verify one of the actions
+        constraintActions.get(0).execute(constraint);
+
+        Mockito.verify(constraint).setForce(true);
+        Mockito.verify(logger).debug("Forced constraint {}", constraint.getName());
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/DependencyConstraintsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/DependencyConstraintsPluginIntegrationTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import java.io.File;
+import java.net.URL;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(value = { IntegrationTestListener.class })
+public class DependencyConstraintsPluginIntegrationTest {
+
+    private File testProjectDirectoryAll;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        URL directory = this.getClass().getClassLoader()
+                .getResource("org/starchartlabs/flare/plugins/test/dependency/constraints");
+
+        testProjectDirectoryAll = new File(directory.toURI());
+    }
+
+    @Test
+    public void applyConstraints() throws Exception {
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(testProjectDirectoryAll)
+                .withArguments("tasks", "--info")
+                .withGradleVersion("5.0")
+                .build();
+
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':compile' dependency constraint: group:artifact:1.0"));
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':compile' dependency constraint: group2:artifact2:2.0"));
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':createdAfterDsl' dependency constraint: group:artifact:1.0"));
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':createdAfterDsl' dependency constraint: group2:artifact2:2.0"));
+
+        TaskOutcome outcome = result.task(":tasks").getOutcome();
+        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/DependencyConstraintsPluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/DependencyConstraintsPluginTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.starchartlabs.flare.plugins.model.DependencyConstraints;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class DependencyConstraintsPluginTest {
+
+    private static final String PLUGIN_ID = "org.starchartlabs.flare.dependency-constraints";
+
+    private Project project;
+
+    @BeforeClass
+    public void setupProject() {
+        project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(PLUGIN_ID);
+    }
+
+    @Test
+    public void configurationApplied() throws Exception {
+        Object found = project.getExtensions().findByName("dependencyConstraints");
+
+        Assert.assertNotNull(found);
+        Assert.assertTrue(found instanceof DependencyConstraints);
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/ManagedCredentialsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/ManagedCredentialsPluginIntegrationTest.java
@@ -46,7 +46,7 @@ public class ManagedCredentialsPluginIntegrationTest {
                 .withGradleVersion("5.0")
                 .build();
 
-        result.getOutput().contains(expectedUsername + ":" + expectedPassword);
+        Assert.assertTrue(result.getOutput().contains(expectedUsername + ":" + expectedPassword));
 
         TaskOutcome outcome = result.task(":credentialsPrintout").getOutcome();
         Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
@@ -64,7 +64,7 @@ public class ManagedCredentialsPluginIntegrationTest {
                 .withGradleVersion("5.0")
                 .build();
 
-        result.getOutput().contains(expectedUsername + ":" + expectedPassword);
+        Assert.assertTrue(result.getOutput().contains(expectedUsername + ":" + expectedPassword));
 
         TaskOutcome outcome = result.task(":credentialsPrintout").getOutcome();
         Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+    id  'org.starchartlabs.flare.dependency-constraints'
+    id 'java'
+}
+
+dependencyConstraints {
+    file file('dependencies.properties')
+}
+
+configurations {
+    createdAfterDsl
+}

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/dependencies.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/dependencies.properties
@@ -1,0 +1,4 @@
+group:artifact:1.0
+
+# Another locked version
+group2:artifact2:2.0


### PR DESCRIPTION
Add plug-in which allows loading and applying dependency version
constraints to all configurations with a simple DSL extension