### PR TITLE
Add multi-module-library plug-in to provided plug-in sets

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,3 +9,4 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - managed-credentials plug-in which provides a DSL for re-usable loaded credentials from multiple sources
 - dependency-constraints plug-in which provides a DSL for applying dependency version constraints to all configurations in bulk from an external file
 - merge-coverage-reports plug-in which provides setup for merging all coverage reports into a single XML report for the entire Gradle project
+- multi-module-library plug-in which provides application and default conventions for all Flare plug-ins applicable in a StarChart Labs multi-module library configuration

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.plugin;
+
+import java.io.IOException;
+
+import org.gradle.api.GradleException;
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.starchartlabs.flare.plugins.model.CredentialSet;
+import org.starchartlabs.flare.plugins.model.DependencyConstraints;
+
+/**
+ * Plug-in that applies all Flare plug-ins applicable to StarChart Labs multi-module library configurations, and sets
+ * standard conventions for their use in that context
+ *
+ * @author romeara
+ * @since 0.1.0
+ */
+public class MultiModuleLibraryPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply("org.starchartlabs.flare.merge-coverage-reports");
+
+        project.allprojects(p -> {
+            p.getPluginManager().apply("org.starchartlabs.flare.dependency-constraints");
+            p.getPluginManager().apply("org.starchartlabs.flare.managed-credentials");
+
+            try {
+                DependencyConstraints dependencyConstraints = p.getExtensions().getByType(DependencyConstraints.class);
+                dependencyConstraints
+                .file(project.file(project.getProjectDir().toPath().resolve("dependencies.properties")));
+            } catch (IOException e) {
+                throw new GradleException("Error loading dependency properties", e);
+            }
+
+            @SuppressWarnings("unchecked")
+            NamedDomainObjectContainer<CredentialSet> credentials = (NamedDomainObjectContainer<CredentialSet>) p
+            .getExtensions().getByName("credentials");
+            credentials.add(new CredentialSet("bintray").environment("BINTRAY_USER", "BINTRAY_API_KEY"));
+        });
+    }
+
+}

--- a/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.multi-module-library.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.multi-module-library.properties
@@ -1,0 +1,1 @@
+implementation-class=org.starchartlabs.flare.plugins.plugin.MultiModuleLibraryPlugin

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MergeCoverageReportsPluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MergeCoverageReportsPluginTest.java
@@ -17,7 +17,7 @@ public class MergeCoverageReportsPluginTest {
 
     private static final String PLUGIN_ID = "org.starchartlabs.flare.merge-coverage-reports";
 
-    @Test()
+    @Test
     public void singleProjectWithoutJacoco() throws Exception {
         Project project = ProjectBuilder.builder().build();
         project.getPluginManager().apply(PLUGIN_ID);

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
@@ -18,16 +18,18 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-public class MergeCoverageReportsPluginIntegrationTest {
+public class MultiModuleLibraryPluginIntegrationTest {
 
     private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
-            "merge", "coverage", "reports");
+            "multi", "module", "library");
 
     private static final Path SINGLE_PROJECT_BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("singleProjectBuild.gradle");
 
     private static final Path ROOT_PROJECT_BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("rootProjectBuild.gradle");
 
     private static final Path SUB_PROJECT_BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("subProjectBuild.gradle");
+
+    private static final Path DEPENDENCIES_FILE = BUILD_FILE_DIRECTORY.resolve("dependencies.properties");
 
     private Path singleProjectPath;
 
@@ -39,10 +41,12 @@ public class MergeCoverageReportsPluginIntegrationTest {
                 .addJavaFile("org.starchartlabs.flare.merge.coverage.reports", "Main")
                 .addTestFile("org.starchartlabs.flare.test.merge.coverage.reports", "MainTest",
                         "org.starchartlabs.flare.merge.coverage.reports.Main")
+                .addFile(DEPENDENCIES_FILE, Paths.get("dependencies.properties"))
                 .build()
                 .getProjectDirectory();
 
         multiModuleProjectPath = TestGradleProject.builder(ROOT_PROJECT_BUILD_FILE)
+                .addFile(DEPENDENCIES_FILE, Paths.get("dependencies.properties"))
                 .subProject("one", SUB_PROJECT_BUILD_FILE)
                 .addJavaFile("org.starchartlabs.flare.merge.coverage.reports.one", "MainOne")
                 .addTestFile("org.starchartlabs.flare.test.merge.coverage.reports.one", "MainOneTest",
@@ -62,10 +66,18 @@ public class MergeCoverageReportsPluginIntegrationTest {
         BuildResult result = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(singleProjectPath.toFile())
-                .withArguments("check")
+                .withArguments("check", "--info")
                 .withGradleVersion("5.0")
                 .build();
 
+        // Check constraints application
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':compile' dependency constraint: org.testng:testng:6.14.3"));
+
+        // Check managed credentials setup
+        Assert.assertTrue(result.getOutput().contains("Credentials configured: bintray"));
+
+        // Check merge coverage reports application
         TaskOutcome outcome = result.task(":mergeCoverageReports").getOutcome();
         Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
 
@@ -86,10 +98,20 @@ public class MergeCoverageReportsPluginIntegrationTest {
         BuildResult result = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(multiModuleProjectPath.toFile())
-                .withArguments("check")
+                .withArguments("check", "--info")
                 .withGradleVersion("5.0")
                 .build();
 
+        // Check constraints application
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':one:compile' dependency constraint: org.testng:testng:6.14.3"));
+        Assert.assertTrue(result.getOutput()
+                .contains("Applied configuration ':two:compile' dependency constraint: org.testng:testng:6.14.3"));
+
+        // Check managed credentials setup
+        Assert.assertTrue(result.getOutput().contains("Credentials configured: bintray"));
+
+        // Check merge coverage reports application
         TaskOutcome outcome = result.task(":mergeCoverageReports").getOutcome();
         Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
 

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/dependencies.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/dependencies.properties
@@ -1,0 +1,2 @@
+# Locked version
+org.testng:testng:6.14.3

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/rootProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/rootProjectBuild.gradle
@@ -1,0 +1,19 @@
+plugins {
+    id  'org.starchartlabs.flare.multi-module-library'
+}
+
+allprojects{
+    repositories {
+        jcenter()
+    }
+}
+
+task outputManagedCredentials{
+    doLast{
+        credentials.all{
+            project.logger.lifecycle("Credentials configured: ${it.name}")
+        }
+    }
+}
+
+check.dependsOn outputManagedCredentials

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
@@ -1,0 +1,29 @@
+plugins {
+    id  'org.starchartlabs.flare.multi-module-library'
+    id 'java'
+    id 'jacoco'
+}
+
+repositories {
+    jcenter()
+}
+
+dependencies {
+    testCompile 'org.testng:testng'
+}
+
+test {
+    useTestNG() {
+        useDefaultListeners = true
+    }
+}
+
+task outputManagedCredentials{
+    doLast{
+        credentials.all{
+            project.logger.lifecycle("Credentials configured: ${it.name}")
+        }
+    }
+}
+
+check.dependsOn outputManagedCredentials

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
@@ -1,0 +1,14 @@
+plugins {
+    id 'java'
+    id 'jacoco'
+}
+
+dependencies {
+    testCompile 'org.testng:testng'
+}
+
+test {
+    useTestNG() {
+        useDefaultListeners = true
+    }
+}


### PR DESCRIPTION
Add plug-in which applies all Flare plug-ins applicable to StarChart
Labs multi-module library configurations, and sets default conventions
for those plug-ins