### PR TITLE
Switch all integration tests to TestGradleProject methodology

### DIFF
--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/DependencyConstraintsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/DependencyConstraintsPluginIntegrationTest.java
@@ -6,13 +6,14 @@
  */
 package org.starchartlabs.flare.plugins.test.plugin;
 
-import java.io.File;
-import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.starchartlabs.flare.plugins.test.TestGradleProject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Listeners;
@@ -21,21 +22,28 @@ import org.testng.annotations.Test;
 @Listeners(value = { IntegrationTestListener.class })
 public class DependencyConstraintsPluginIntegrationTest {
 
-    private File testProjectDirectoryAll;
+    private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
+            "dependency", "constraints");
+
+    private static final Path BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("build.gradle");
+
+    private static final Path DEPENDENCIES_FILE = BUILD_FILE_DIRECTORY.resolve("dependencies.properties");
+
+    private Path projectPath;
 
     @BeforeClass
     public void setup() throws Exception {
-        URL directory = this.getClass().getClassLoader()
-                .getResource("org/starchartlabs/flare/plugins/test/dependency/constraints");
-
-        testProjectDirectoryAll = new File(directory.toURI());
+        projectPath = TestGradleProject.builder(BUILD_FILE)
+                .addFile(DEPENDENCIES_FILE, Paths.get("dependencies.properties"))
+                .build()
+                .getProjectDirectory();
     }
 
     @Test
     public void applyConstraints() throws Exception {
         BuildResult result = GradleRunner.create()
                 .withPluginClasspath()
-                .withProjectDir(testProjectDirectoryAll)
+                .withProjectDir(projectPath.toFile())
                 .withArguments("tasks", "--info")
                 .withGradleVersion("5.0")
                 .build();

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/IncreasedTestLoggingPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/IncreasedTestLoggingPluginIntegrationTest.java
@@ -6,13 +6,14 @@
  */
 package org.starchartlabs.flare.plugins.test.plugin;
 
-import java.io.File;
-import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.starchartlabs.flare.plugins.test.TestGradleProject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Listeners;
@@ -21,21 +22,25 @@ import org.testng.annotations.Test;
 @Listeners(value = { IntegrationTestListener.class })
 public class IncreasedTestLoggingPluginIntegrationTest {
 
-    private File testProjectDirectory;
+    private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
+            "increased", "test", "logging");
+
+    private static final Path BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("build.gradle");
+
+    private Path projectPath;
 
     @BeforeClass
     public void setup() throws Exception {
-        URL directory = this.getClass().getClassLoader()
-                .getResource("org/starchartlabs/flare/plugins/test/increased/test/logging");
-
-        testProjectDirectory = new File(directory.toURI());
+        projectPath = TestGradleProject.builder(BUILD_FILE)
+                .build()
+                .getProjectDirectory();
     }
 
     @Test
     public void applyPlugin() throws Exception {
         BuildResult result = GradleRunner.create()
                 .withPluginClasspath()
-                .withProjectDir(testProjectDirectory)
+                .withProjectDir(projectPath.toFile())
                 .withArguments("testPrintout")
                 .withGradleVersion("5.0")
                 .build();

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/ManagedCredentialsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/ManagedCredentialsPluginIntegrationTest.java
@@ -6,13 +6,14 @@
  */
 package org.starchartlabs.flare.plugins.test.plugin;
 
-import java.io.File;
-import java.net.URL;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import org.gradle.testkit.runner.BuildResult;
 import org.gradle.testkit.runner.GradleRunner;
 import org.gradle.testkit.runner.TaskOutcome;
 import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.starchartlabs.flare.plugins.test.TestGradleProject;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Listeners;
@@ -21,14 +22,18 @@ import org.testng.annotations.Test;
 @Listeners(value = { IntegrationTestListener.class })
 public class ManagedCredentialsPluginIntegrationTest {
 
-    private File testProjectDirectory;
+    private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
+            "managed", "credentials");
+
+    private static final Path BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("build.gradle");
+
+    private Path projectPath;
 
     @BeforeClass
     public void setup() throws Exception {
-        URL directory = this.getClass().getClassLoader()
-                .getResource("org/starchartlabs/flare/plugins/test/managed/credentials");
-
-        testProjectDirectory = new File(directory.toURI());
+        projectPath = TestGradleProject.builder(BUILD_FILE)
+                .build()
+                .getProjectDirectory();
     }
 
     // TODO romeara Try to figure out a way to test the environment variable scenario
@@ -40,7 +45,7 @@ public class ManagedCredentialsPluginIntegrationTest {
 
         BuildResult result = GradleRunner.create()
                 .withPluginClasspath()
-                .withProjectDir(testProjectDirectory)
+                .withProjectDir(projectPath.toFile())
                 .withArguments("credentialsPrintout", "-Dproperty_1=" + expectedUsername,
                         "-Dproperty_2=" + expectedPassword)
                 .withGradleVersion("5.0")
@@ -59,7 +64,7 @@ public class ManagedCredentialsPluginIntegrationTest {
 
         BuildResult result = GradleRunner.create()
                 .withPluginClasspath()
-                .withProjectDir(testProjectDirectory)
+                .withProjectDir(projectPath.toFile())
                 .withArguments("credentialsPrintout")
                 .withGradleVersion("5.0")
                 .build();


### PR DESCRIPTION
Previously, there were multiple methods for integration-testing plug-ins
with real project setups - directly referencing files in-place, and
creating temporary projects. While the first resulted in less file IO,
the second allows for more complex setups. In the interest of
standardizing how these tests are written, the second should be applied
to all test setups.

This change set applies the temporary project method to all integration
tests not previously using it