### PR TITLE
Add project meta data DSL for defining project management information

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 - source-jars plug-in which provides tasks to build source and javadoc jars and adds them to the project's archives artifact configuration
 - Integrate source-jars with maven-publish plug-in as published artifacts
+- metadata-base plug-in which provides a DSL for re-usable project meta data values
 
 ## [0.1.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Applying this convention has the following effects:
   - These credentials can be referenced by `${credentials.bintray.username}` and `${credentials.bintray.password}'
 - Increases the logging level of test events in sub-modules
 - Adds tasks to generate sources and javadoc jars, and adds them to the project's acrhives artifact configuration
+- Adds DSL for configuration project meta data
+- Loads developers into project meta data from file `"${rootDir}/developers.properties"`, if it exists
+- Loads contributors into project meta data from file `"${rootDir}/contributors.properties"`, if it exists
 
 Individual plug-ins used to apply these changes:
 
@@ -45,6 +48,7 @@ Individual plug-ins used to apply these changes:
 - org.starchartlabs.flare.managed-credentials
 - org.starchartlabs.flare.merge-coverage-reports
 - org.starchartlabs.flare.source-jars
+- org.starchartlabs.flare.metadata-base
 
 ## Migrating From Previous Plug-ins
 

--- a/docs/FLARE_PUBLISHING_MIGRATION.md
+++ b/docs/FLARE_PUBLISHING_MIGRATION.md
@@ -11,3 +11,7 @@ No change aside from switch the imported library is required - the plug-in ID is
 ## org.starchartlabs.flare.pom-source-jar-artifacts
 
 The functionality of the `pom-source-jar-artifacts` plug-in has been combined with the `source-jars` plug-in, and will be conditionally applied if the `maven-publish` plug-in is used
+
+## org.starchartlabs.flare.published-info-base
+
+The DSL of the published info plug-in has been re-designed, and is now the metadata-base plug in. See the [new plug-ins](./PLUGINS.md) documentation for details on the new DSL form. All previous `publishedInfo` values are supported

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -83,3 +83,66 @@ The merge-coverage-reports plug-in adds a task which generates a single XML Jaco
 The source-jars plug-in adds two tasks of type `Jar` - `sourcesJar`, which generates a jar file with the source files of the project, and `javadocJar`, which generates a jar file with the javadoc files of the project. These tasks are added to the `archives` artifact configuration of the project, and if the `maven-publish` plug-in is used, they are added as artifacts with the `sources` and `javadoc` classifiers.
 
 These jars are intended to be uploaded alongside binary artifacts for open-source projects. They allow developers to trace through the associated code paths when debugging, and to view associated Javadoc documentation within their IDE.
+
+## org.starchartlabs.flare.metadata-base
+
+The metadata-base plug-in adds a configuration DSL for defining re-usable project meta data values within the build. The primary intended use for these values is as properties on generated artifacts
+
+### DSL
+
+The DSL is named `projectMetaData`, and allows defining information such as source control management locations, licensing, and individuals associated with the repository
+
+Meta data can be defined manually, or via GitHub conventions:
+
+#### Manual DSL
+
+```
+projectMetaData{
+	url = 'http://...'
+	
+	scm {
+		vcsUrl = 'http://...'
+		connection = 'http://...'
+		developerConnection = 'http://..'
+	}
+	
+	developers {
+		developer 'id', 'name', 'http://...'
+	}
+	
+	contributors {
+		contributor 'name', 'http://...'
+	}
+	
+	licenses {
+		mit('repo')
+	}
+}
+```
+
+#### GitHub DSL
+
+projectMetaData{
+	github {
+		repository 'owner', 'repository'
+		
+		developer 'octocat', 'Octocat'
+		contributor 'hue'
+	}
+	
+	licenses {
+		mit('repo')
+	}
+}
+
+In addition to the standard DSL within the build file, the `github` configuration DSL allows loading developers and contributors from an external file. This file may have blank links, comment lines (starting with `#`), and configuration lines. Configuration lines are of the form `username` or `username, name`
+
+#### License Meta Data
+
+Regradless of use of the GitHub configuration DSL, meta data configuration includes specification of the project license. This can be done manually by providing name, tag, url, and maven distribution method (`repo` or `manual`), or by using a pre-specified license. Currently, the following licenses are pre-configured in teh DSL definition:
+
+* Apache 2.0 (`apache2`)
+* MIT (`mit`)
+* Eclipse Public License 1.0 (`epl`)
+
+All licenses have a DSL which omits distribution (defaulting to `repo`), and a DSL which accepts a distribution specification. Pull requests to add additional pre-configured licenses are welcome!

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Contributor.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Contributor.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents an individual who does not hold responsibilities for maintaining a project, but has contributed work
+ * towards it
+ *
+ * <p>
+ * Based of Maven POM definition of a <a href="https://maven.apache.org/pom.html#Contributors">contributor</a>
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class Contributor {
+
+    private String name;
+
+    private String url;
+
+    /**
+     * Initializes an empty contributor record
+     *
+     * @since 0.2.0
+     */
+    public Contributor() {
+        this(null, null);
+    }
+
+    /**
+     * @param name
+     *            Name of the contributor
+     * @param url
+     *            URL where information about the contributor is available
+     * @since 0.2.0
+     */
+    public Contributor(@Nullable String name, @Nullable String url) {
+        this.name = name;
+        this.url = url;
+    }
+
+    /**
+     * Allows external configuration of the contributor. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param closure
+     *            Closure to configure the contributor
+     * @return This (configured) contributor
+     * @since 0.2.0
+     */
+    public Contributor configure(Closure<Contributor> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Allows external configuration of the contributor. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param action
+     *            Action to configure the contributor
+     * @return This (configured) contributor
+     * @since 0.2.0
+     */
+    public Contributor configure(Action<Contributor> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return Name of the contributor
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name
+     *            Name of the contributor
+     * @since 0.2.0
+     */
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return URL where information about the contributor is available
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url
+     *            URL where information about the contributor is available
+     * @since 0.2.0
+     */
+    public void setUrl(@Nullable String url) {
+        this.url = url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(),
+                getUrl());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof Contributor) {
+            Contributor compare = (Contributor) obj;
+
+            result = Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getUrl(), getUrl());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("name", getName())
+                .add("url", getUrl())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ContributorContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ContributorContainer.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents management and operations for the contributors associated with a repository
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class ContributorContainer {
+
+    private Collection<Contributor> contributors;
+
+    /**
+     * Initializes an empty contributor management container
+     *
+     * @since 0.2.0
+     */
+    public ContributorContainer() {
+        this.contributors = new ArrayList<>();
+    }
+
+    /**
+     * Configures this container via the specified closure
+     *
+     * @param closure
+     *            An closure used to configure the container
+     * @return This container instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ContributorContainer configure(Closure<ContributorContainer> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Configures this container via the specified action
+     *
+     * @param action
+     *            An action used to configure the container
+     * @return This container instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ContributorContainer configure(Action<ContributorContainer> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return The contributors currently managed by the container
+     * @since 0.2.0
+     */
+    public Collection<Contributor> getContributors() {
+        return contributors;
+    }
+
+    /**
+     * Overwrites the current contributors within this container with the provided collection
+     *
+     * @param contributors
+     *            A collection of contributors to set this container to
+     * @since 0.2.0
+     */
+    public void setContributors(Collection<Contributor> contributors) {
+        Objects.requireNonNull(contributors);
+
+        this.contributors = contributors;
+    }
+
+    /**
+     * Configures a new contributor to add to the set of contributors
+     *
+     * @param name
+     *            Name of the contributor
+     * @param url
+     *            URL where information about the contributor is available
+     * @return This contributor container, with the specified contributor added
+     * @since 0.2.0
+     */
+    public ContributorContainer contributor(String name, String url) {
+        contributors.add(new Contributor(name, url));
+
+        return this;
+    }
+
+    /**
+     * Configures a new contributor to add to the set of contributors
+     *
+     * @param closure
+     *            A closure used to configure a single contributor
+     * @return This contributor container, with the specified contributor added
+     * @since 0.2.0
+     */
+    public ContributorContainer contributor(Closure<Contributor> closure) {
+        Objects.requireNonNull(closure);
+
+        contributors.add(new Contributor().configure(closure));
+
+        return this;
+    }
+
+    /**
+     * Configures a new contributor to add to the set of contributors
+     *
+     * @param action
+     *            An action used to configure a single contributor
+     * @return This contributor container, with the specified contributor added
+     * @since 0.2.0
+     */
+    public ContributorContainer contributor(Action<Contributor> action) {
+        Objects.requireNonNull(action);
+
+        contributors.add(new Contributor().configure(action));
+
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getContributors());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof ContributorContainer) {
+            ContributorContainer compare = (ContributorContainer) obj;
+
+            result = Objects.equals(compare.getContributors(), getContributors());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("contributors", getContributors())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Developer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Developer.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents an individual who holds responsibilities for maintaining a project
+ *
+ * <p>
+ * Based of Maven POM definition of a <a href="https://maven.apache.org/pom.html#Developers">developer</a>
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class Developer {
+
+    private String id;
+
+    private String name;
+
+    private String url;
+
+    /**
+     * Initializes an empty developer record
+     *
+     * @since 0.2.0
+     */
+    public Developer() {
+        this(null, null, null);
+    }
+
+    /**
+     * @param id
+     *            Unique identifier of the developer within the organization
+     * @param name
+     *            Name of the developer
+     * @param url
+     *            URL where information about the developer is available
+     * @since 0.2.0
+     */
+    public Developer(@Nullable String id, @Nullable String name, @Nullable String url) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
+    }
+
+    /**
+     * Allows external configuration of the developer. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param closure
+     *            Closure to configure the developer
+     * @return This (configured) developer
+     * @since 0.2.0
+     */
+    public Developer configure(Closure<Developer> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Allows external configuration of the developer. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param action
+     *            Action to configure the developer
+     * @return This (configured) developer
+     * @since 0.2.0
+     */
+    public Developer configure(Action<Developer> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return Unique identifier of the developer within the organization
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * @param id
+     *            Unique identifier of the developer within the organization
+     * @since 0.2.0
+     */
+    public void setId(@Nullable String id) {
+        this.id = id;
+    }
+
+    /**
+     * @return Name of the developer
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name
+     *            Name of the developer
+     * @since 0.2.0
+     */
+    public void setName(@Nullable String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return URL where information about the developer is available
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url
+     *            URL where information about the developer is available
+     * @since 0.2.0
+     */
+    public void setUrl(@Nullable String url) {
+        this.url = url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(),
+                getName(),
+                getUrl());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof Developer) {
+            Developer compare = (Developer) obj;
+
+            result = Objects.equals(compare.getId(), getId())
+                    && Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getUrl(), getUrl());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("id", getId())
+                .add("name", getName())
+                .add("url", getUrl())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/DeveloperContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/DeveloperContainer.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents management and operations for the developers associated with a repository
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class DeveloperContainer {
+
+    private Collection<Developer> developers;
+
+    /**
+     * Initializes an empty developer management container
+     *
+     * @since 0.2.0
+     */
+    public DeveloperContainer() {
+        this.developers = new ArrayList<>();
+    }
+
+    /**
+     * Configures this container via the specified closure
+     *
+     * @param closure
+     *            An closure used to configure the container
+     * @return This container instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public DeveloperContainer configure(Closure<DeveloperContainer> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Configures this container via the specified action
+     *
+     * @param action
+     *            An action used to configure the container
+     * @return This container instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public DeveloperContainer configure(Action<DeveloperContainer> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return The developers currently managed by the container
+     * @since 0.2.0
+     */
+    public Collection<Developer> getDevelopers() {
+        return developers;
+    }
+
+    /**
+     * Overwrites the current developers within this container with the provided collection
+     *
+     * @param developers
+     *            A collection of developers to set this container to
+     * @since 0.2.0
+     */
+    public void setDevelopers(Collection<Developer> developers) {
+        Objects.requireNonNull(developers);
+
+        this.developers = developers;
+    }
+
+    /**
+     * Configures a new developer to add to the set of developers
+     *
+     * @param id
+     *            Unique identifier of the developer within the organization
+     * @param name
+     *            Name of the developer
+     * @param url
+     *            URL where information about the developer is available
+     * @return This developer container, with the specified developer added
+     * @since 0.2.0
+     */
+    public DeveloperContainer developer(String id, String name, String url) {
+        developers.add(new Developer(id, name, url));
+
+        return this;
+    }
+
+    /**
+     * Configures a new developer to add to the set of developers
+     *
+     * @param closure
+     *            A closure used to configure a single developer
+     * @return This developer container, with the specified developer added
+     * @since 0.2.0
+     */
+    public DeveloperContainer developer(Closure<Developer> closure) {
+        Objects.requireNonNull(closure);
+
+        developers.add(new Developer().configure(closure));
+
+        return this;
+    }
+
+    /**
+     * Configures a new developer to add to the set of developers
+     *
+     * @param action
+     *            An action used to configure a single developer
+     * @return This developer container, with the specified developer added
+     * @since 0.2.0
+     */
+    public DeveloperContainer developer(Action<Developer> action) {
+        Objects.requireNonNull(action);
+
+        developers.add(new Developer().configure(action));
+
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getDevelopers());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof DeveloperContainer) {
+            DeveloperContainer compare = (DeveloperContainer) obj;
+
+            result = Objects.equals(compare.getDevelopers(), getDevelopers());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("developers", getDevelopers())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/GitHubMetaData.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/GitHubMetaData.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.Objects;
+import java.util.function.Consumer;
+
+import org.gradle.api.GradleException;
+import org.starchartlabs.alloy.core.Preconditions;
+import org.starchartlabs.alloy.core.Strings;
+
+/**
+ * Represent various domain-specific language definitions configuration of GitHub repository projects
+ *
+ * <p>
+ * Applies GitHub-standard values for a variety of project meta data
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class GitHubMetaData {
+
+    private static final String REPOSITORY_URL_TEMPLATE = "https://github.com/%s/%s";
+
+    private static final String CONNECTION_TEMPLATE = "scm:git:git://github.com/%s/%s.git";
+
+    private static final String DEVELOPER_CONNECTION_TEMPLATE = "scm:git:ssh://github.com/%s/%s.git";
+
+    private static final String USER_URL_TEMPLATE = "https://github.com/%s";
+
+    private final ProjectMetaData delegate;
+
+    /**
+     * @param delegate
+     *            The project meta data to configure when DSL methods are invoked
+     * @since 0.2.0
+     */
+    public GitHubMetaData(ProjectMetaData delegate) {
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    /**
+     * Configures project URL and SCM meta data based on GitHub standards for a hosted repository
+     *
+     * @param owner
+     *            The name of the repository owner
+     * @param repository
+     *            The name of the repository
+     * @since 0.2.0
+     */
+    public void repository(String owner, String repository) {
+        Objects.requireNonNull(owner);
+        Objects.requireNonNull(repository);
+
+        String url = Strings.format(REPOSITORY_URL_TEMPLATE, owner, repository);
+
+        delegate.setUrl(url);
+
+        delegate.getScm().setVcsUrl(url);
+        delegate.getScm().setConnection(Strings.format(CONNECTION_TEMPLATE, owner, repository));
+        delegate.getScm().setDeveloperConnection(Strings.format(DEVELOPER_CONNECTION_TEMPLATE, owner, repository));
+    }
+
+    /**
+     * Adds a developer to project meta data
+     *
+     * @param username
+     *            Username to use as the developer's id, name, and when constructing the GitHub user URL to assign to
+     *            the developer
+     * @since 0.2.0
+     */
+    public void developer(String username) {
+        Objects.requireNonNull(username);
+
+        developer(username, username);
+    }
+
+    /**
+     * Adds a developer to project meta data
+     *
+     * @param username
+     *            Username to use as the developer's id, and when constructing the GitHub user URL to assign to the
+     *            developer
+     * @param name
+     *            Name to assign the developer
+     * @since 0.2.0
+     */
+    public void developer(String username, String name) {
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(name);
+
+        delegate.developers(
+                container -> container.developer(username, name, Strings.format(USER_URL_TEMPLATE, username)));
+    }
+
+    /**
+     * Applies GitHub developers from a file
+     *
+     * <p>
+     * The provided file may have blank lines, comment lines (starting with '#'), and developer lines. Developer lines
+     * must be of the form 'username' or 'username, name'. Developers will be added to the project meta data with an id
+     * of the provider username, name of the provided name or username, and a GitHub user URL for the provided username
+     *
+     * @param file
+     *            File describing developers to add
+     * @since 0.2.0
+     */
+    public void developers(File file) {
+        Objects.requireNonNull(file);
+
+        loadUserFile(file, this::addDeveloper);
+    }
+
+    /**
+     * Adds a contributor to project meta data
+     *
+     * @param username
+     *            Username to use as the contributors name, and when constructing the GitHub user URL to assign to the
+     *            contributor
+     * @since 0.2.0
+     */
+    public void contributor(String username) {
+        Objects.requireNonNull(username);
+
+        contributor(username, username);
+    }
+
+    /**
+     * Adds a contributor to project meta data
+     *
+     * @param username
+     *            Username to use when constructing the GitHub user URL to assign to the contributor
+     * @param name
+     *            Name to assign the contributor
+     * @since 0.2.0
+     */
+    public void contributor(String username, String name) {
+        Objects.requireNonNull(username);
+        Objects.requireNonNull(name);
+
+        delegate.contributors(
+                container -> container.contributor(name, Strings.format(USER_URL_TEMPLATE, username)));
+    }
+
+    /**
+     * Applies GitHub contributors from a file
+     *
+     * <p>
+     * The provided file may have blank lines, comment lines (starting with '#'), and contributor lines. Contributor
+     * lines must be of the form 'username' or 'username, name'. Contributors will be added to the project meta data
+     * with a name of the provided name or username, and a GitHub user URL for the provided username
+     *
+     * @param file
+     *            File describing contributors to add
+     * @since 0.2.0
+     */
+    public void contributors(File file) {
+        Objects.requireNonNull(file);
+
+        loadUserFile(file, this::addContributor);
+    }
+
+    /**
+     * Loads lines from a file to apply as configuration to project meta data
+     *
+     * <p>
+     * Files may have configuration lines, blank lines, and lines preceded with a "#" (comment lines). Blank and comment
+     * lines will be discarded. Configuration lines will be split on "," before being supplied to the provided consumer
+     *
+     * @param file
+     *            The file to process
+     * @param lineHandler
+     *            Function to apply to parsed configuration lines
+     */
+    private void loadUserFile(File file, Consumer<String[]> lineHandler) {
+        Objects.requireNonNull(file);
+        Preconditions.checkArgument(file.exists(),
+                () -> Strings.format("User file does not exist at '%s'", file.getAbsolutePath()));
+
+        try {
+            Files.lines(file.toPath(), StandardCharsets.UTF_8)
+            .map(String::trim)
+            .filter(s -> !s.isEmpty())
+            .filter(s -> !s.startsWith("#"))
+            .map(s -> s.split(","))
+            .forEach(lineHandler);
+        } catch (IOException e) {
+            throw new GradleException(String.format("Error reading user file at '%s'", file.getAbsolutePath()));
+        }
+    }
+
+    /**
+     * Parses a file line representing a GitHub developer to a project
+     *
+     * @param line
+     *            A line of the form "name" or "username, name"
+     */
+    private void addDeveloper(String[] line) {
+        Objects.requireNonNull(line);
+        Preconditions.checkArgument(line.length > 0 && line.length < 3,
+                "Developer specifications must be of form 'username' or 'username, name'");
+
+        if (line.length > 1) {
+            developer(line[0].trim(), line[1].trim());
+        } else {
+            developer(line[0].trim());
+        }
+    }
+
+    /**
+     * Parses a file line representing a GitHub contributor to a project
+     *
+     * @param line
+     *            A line of the form "name" or "username, name"
+     */
+    private void addContributor(String[] line) {
+        Objects.requireNonNull(line);
+        Preconditions.checkArgument(line.length > 0 && line.length < 3,
+                "Contributor specifications must be of form 'username' or 'username, name'");
+
+        if (line.length > 1) {
+            contributor(line[0].trim(), line[1].trim());
+        } else {
+            contributor(line[0].trim());
+        }
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/License.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/License.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents a set of terms that govern legal use of the code within a project
+ *
+ * <p>
+ * Based of Maven POM definition of a <a href="https://maven.apache.org/pom.html#Licenses">license</a>
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class License {
+
+    private String name;
+
+    private String tag;
+
+    private String url;
+
+    private String distribution;
+
+    /**
+     * Initializes an empty license record
+     *
+     * @since 0.2.0
+     */
+    public License() {
+        this(null, null, null, null);
+    }
+
+    /**
+     * @param name
+     *            Name of the license
+     * @param tag
+     *            Shorthand used to reference the license. (ex: "MIT" for The MIT License)
+     * @param url
+     *            The official URL for the license text
+     * @param distribution
+     *            The primary method by which this project may be distributed. "repo" for projects distributed via Maven
+     *            Central, "manual" for manual download
+     * @since 0.2.0
+     */
+    public License(String name, String tag, String url, String distribution) {
+        this.name = name;
+        this.tag = tag;
+        this.url = url;
+        this.distribution = distribution;
+    }
+
+    /**
+     * Allows external configuration of the license. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param closure
+     *            Closure to configure the license
+     * @return This (configured) license
+     * @since 0.2.0
+     */
+    public License configure(Closure<License> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Allows external configuration of the license. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param action
+     *            Action to configure the license
+     * @return This (configured) license
+     * @since 0.2.0
+     */
+    public License configure(Action<License> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return Name of the license
+     * @since 0.2.0
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param name
+     *            Name of the license
+     * @since 0.2.0
+     */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /**
+     * @return Shorthand used to reference the license. (ex: "MIT" for The MIT License)
+     * @since 0.2.0
+     */
+    public String getTag() {
+        return tag;
+    }
+
+    /**
+     * @param tag
+     *            Shorthand used to reference the license. (ex: "MIT" for The MIT License)
+     * @since 0.2.0
+     */
+    public void setTag(String tag) {
+        this.tag = tag;
+    }
+
+    /**
+     * @return The official URL for the license text
+     * @since 0.2.0
+     */
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url
+     *            The official URL for the license text
+     * @since 0.2.0
+     */
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    /**
+     * @return The primary method by which this project may be distributed. "repo" for projects distributed via Maven
+     *         Central, "manual" for manual download
+     * @since 0.2.0
+     */
+    public String getDistribution() {
+        return distribution;
+    }
+
+    /**
+     * @param distribution
+     *            The primary method by which this project may be distributed. "repo" for projects distributed via Maven
+     *            Central, "manual" for manual download
+     * @since 0.2.0
+     */
+    public void setDistribution(String distribution) {
+        this.distribution = distribution;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(),
+                getTag(),
+                getUrl(),
+                getDistribution());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof License) {
+            License compare = (License) obj;
+
+            result = Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getTag(), getTag())
+                    && Objects.equals(compare.getUrl(), getUrl())
+                    && Objects.equals(compare.getDistribution(), getDistribution());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("name", getName())
+                .add("tag", getTag())
+                .add("url", getUrl())
+                .add("distribution", getDistribution())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/LicenseContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/LicenseContainer.java
@@ -1,0 +1,247 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents management and operations for the licenses associated with a repository
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class LicenseContainer {
+
+    private static final String REPOSITORY_DISTRIBUTION = "repo";
+
+    private Collection<License> licenses;
+
+    /**
+     * Initializes an empty license management container
+     *
+     * @since 0.2.0
+     */
+    public LicenseContainer() {
+        this.licenses = new ArrayList<>();
+    }
+
+    /**
+     * Configures this container via the specified closure
+     *
+     * @param closure
+     *            An closure used to configure the container
+     * @return This container instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer configure(Closure<LicenseContainer> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Configures this container via the specified action
+     *
+     * @param action
+     *            An action used to configure the container
+     * @return This container instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer configure(Action<LicenseContainer> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return The licenses currently managed by the container
+     * @since 0.2.0
+     */
+    public Collection<License> getLicenses() {
+        return licenses;
+    }
+
+    /**
+     * Overwrites the current licenses within this container with the provided collection
+     *
+     * @param licenses
+     *            A collection of licenses to set this container to
+     * @since 0.2.0
+     */
+    public void setLicenses(Collection<License> licenses) {
+        Objects.requireNonNull(licenses);
+
+        this.licenses = licenses;
+    }
+
+    /**
+     * Adds a license to the project
+     *
+     * @param name
+     *            The full legal name of the license
+     * @param tag
+     *            Shorthand used to reference the license. (ex: "MIT" for The MIT License)
+     * @param url
+     *            The official URL for the license text
+     * @param distribution
+     *            The primary method by which this project may be distributed. "repo" for projects distributed via Maven
+     *            Central, "manual" for manual download
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer license(String name, String tag, String url, String distribution) {
+        licenses.add(new License(name, tag, url, distribution));
+
+        return this;
+    }
+
+    /**
+     * Configures a new license to add to the set of licenses
+     *
+     * @param closure
+     *            A closure used to configure a single license
+     * @return This license container, with the specified license added
+     * @since 0.2.0
+     */
+    public LicenseContainer license(Closure<License> closure) {
+        Objects.requireNonNull(closure);
+
+        licenses.add(new License().configure(closure));
+
+        return this;
+    }
+
+    /**
+     * Configures a new license to add to the set of licenses
+     *
+     * @param action
+     *            An action used to configure a single license
+     * @return This license container, with the specified license added
+     * @since 0.2.0
+     */
+    public LicenseContainer license(Action<License> action) {
+        Objects.requireNonNull(action);
+
+        licenses.add(new License().configure(action));
+
+        return this;
+    }
+
+    /**
+     * Adds the Apache 2.0 license to the licenses the project may be used under with the "repo" distribution
+     * 
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer apache2() {
+        return apache2(REPOSITORY_DISTRIBUTION);
+    }
+
+    /**
+     * Adds the Apache 2.0 license to the licenses the project may be used under
+     *
+     * @param distribution
+     *            The distribution method ("repo" or "manual") the project may use with this license
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer apache2(String distribution) {
+        licenses.add(new License("The Apache Software License, Version 2.0", "Apache 2.0",
+                "http://www.apache.org/licenses/LICENSE-2.0.txt", distribution));
+
+        return this;
+    }
+
+    /**
+     * Adds the MIT license to the licenses the project may be used under with the "repo" distribution
+     * 
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer mit() {
+        return mit(REPOSITORY_DISTRIBUTION);
+    }
+
+    /**
+     * Adds the MIT license to the licenses the project may be used under
+     *
+     * @param distribution
+     *            The distribution method ("repo" or "manual") the project may use with this license
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer mit(String distribution) {
+        licenses.add(new License("The MIT License", "MIT", "https://opensource.org/licenses/MIT", distribution));
+
+        return this;
+    }
+
+    /**
+     * Adds the EPL 1.0 license to the licenses the project may be used under with the "repo" distribution
+     * 
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer epl() {
+        return epl(REPOSITORY_DISTRIBUTION);
+    }
+
+    /**
+     * Adds the EPL 1.0 license to the licenses the project may be used under
+     *
+     * @param distribution
+     *            The distribution method ("repo" or "manual") the project may use with this license
+     * @return This container with configuration applied
+     * @since 0.2.0
+     */
+    public LicenseContainer epl(String distribution) {
+        licenses.add(new License("Eclipse Public License 1.0", "EPL", "https://opensource.org/licenses/EPL-1.0",
+                distribution));
+
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getLicenses());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof LicenseContainer) {
+            LicenseContainer compare = (LicenseContainer) obj;
+
+            result = Objects.equals(compare.getLicenses(), getLicenses());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("licenses", getLicenses())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ProjectMetaData.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ProjectMetaData.java
@@ -1,0 +1,362 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents project management meta data for a repository/project
+ *
+ * <p>
+ * This includes information such as source control, individuals who maintain or contribute to its development, and
+ * licensing
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class ProjectMetaData {
+
+    private String url;
+
+    private Scm scm;
+
+    private DeveloperContainer developers;
+
+    private ContributorContainer contributors;
+
+    private LicenseContainer licenses;
+
+    /**
+     * Initializes a new emty meta data instance
+     *
+     * @since 0.2.0
+     */
+    public ProjectMetaData() {
+        this(null, new Scm(), new DeveloperContainer(), new ContributorContainer(), new LicenseContainer());
+    }
+
+    /**
+     * @param url
+     *            Primary URL of the project
+     * @param scm
+     *            Source control management information associated with the project
+     * @param developers
+     *            Configuration of developers associated with the project
+     * @param contributors
+     *            Configuration of any contributors to the project
+     * @param licenses
+     *            Licensing terms of the project
+     * @since 0.2.0
+     */
+    public ProjectMetaData(@Nullable String url, Scm scm, DeveloperContainer developers,
+            ContributorContainer contributors, LicenseContainer licenses) {
+        this.url = url;
+        this.scm = Objects.requireNonNull(scm);
+        this.developers = Objects.requireNonNull(developers);
+        this.contributors = Objects.requireNonNull(contributors);
+        this.licenses = Objects.requireNonNull(licenses);
+    }
+
+    /**
+     * Allows configuration of multiple values based on GitHub conventions
+     *
+     * @param closure
+     *            A closure to apply to a GitHub DSL for configuration of project meta data
+     * @return This project meta data with values applied from the GitHub DSL
+     * @since 0.2.0
+     */
+    public ProjectMetaData github(Closure<GitHubMetaData> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(new GitHubMetaData(this));
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Allows configuration of multiple values based on GitHub conventions
+     *
+     * @param action
+     *            An action to apply to a GitHub DSL for configuration of project meta data
+     * @return This project meta data with values applied from the GitHub DSL
+     * @since 0.2.0
+     */
+    public ProjectMetaData github(Action<GitHubMetaData> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(new GitHubMetaData(this));
+
+        return this;
+    }
+
+    /**
+     * @return Primary URL of the project
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getUrl() {
+        return url;
+    }
+
+    /**
+     * @param url
+     *            Primary URL of the project
+     * @since 0.2.0
+     */
+    public void setUrl(@Nullable String url) {
+        this.url = url;
+    }
+
+    /**
+     * @return Source control management information associated with the project
+     * @since 0.2.0
+     */
+    public Scm getScm() {
+        return scm;
+    }
+
+    /**
+     * @param scm
+     *            Source control management information associated with the project
+     * @since 0.2.0
+     */
+    public void setScm(Scm scm) {
+        this.scm = Objects.requireNonNull(scm);
+    }
+
+    /**
+     * Allows external configuration of the scm. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param closure
+     *            Closure to configure the scm
+     * @return This meta data instance with configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData scm(Closure<Scm> closure) {
+        Objects.requireNonNull(closure);
+
+        scm.configure(closure);
+
+        return this;
+    }
+
+    /**
+     * Allows external configuration of the scm. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param action
+     *            Action to configure the scm
+     * @return This meta data instance with configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData scm(Action<Scm> action) {
+        Objects.requireNonNull(action);
+
+        scm.configure(action);
+
+        return this;
+    }
+
+    /**
+     * @return The developers currently configured on this meta data
+     * @since 0.2.0
+     */
+    public Collection<Developer> getDevelopers() {
+        return developers.getDevelopers();
+    }
+
+    /**
+     * Overwrites the current developers within this meta data with the provided collection
+     *
+     * @param developers
+     *            A collection of developers to set this meta data to
+     * @since 0.2.0
+     */
+    public void setDevelopers(Collection<Developer> developers) {
+        this.developers.setDevelopers(developers);
+    }
+
+    /**
+     * Configures developers for this meta data via the specified action
+     *
+     * @param closure
+     *            A closure used to configure the developers
+     * @return This meta data instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData developers(Closure<DeveloperContainer> closure) {
+        Objects.requireNonNull(closure);
+
+        developers.configure(closure);
+
+        return this;
+    }
+
+    /**
+     * Configures developers for this meta data via the specified action
+     *
+     * @param action
+     *            An action used to configure the developers
+     * @return This meta data instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData developers(Action<DeveloperContainer> action) {
+        Objects.requireNonNull(action);
+
+        developers.configure(action);
+
+        return this;
+    }
+
+    /**
+     * @return The contributors currently configured on this meta data
+     * @since 0.2.0
+     */
+    public Collection<Contributor> getContributors() {
+        return contributors.getContributors();
+    }
+
+    /**
+     * Overwrites the current contributors within this meta data with the provided collection
+     *
+     * @param contributors
+     *            A collection of contributors to set this meta data to
+     * @since 0.2.0
+     */
+    public void setContributors(Collection<Contributor> contributors) {
+        this.contributors.setContributors(contributors);
+    }
+
+    /**
+     * Configures contributors for this meta data via the specified action
+     *
+     * @param closure
+     *            A closure used to configure the contributors
+     * @return This meta data instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData contributors(Closure<ContributorContainer> closure) {
+        Objects.requireNonNull(closure);
+
+        contributors.configure(closure);
+
+        return this;
+    }
+
+    /**
+     * Configures contributors for this meta data via the specified action
+     *
+     * @param action
+     *            An action used to configure the contributors
+     * @return This meta data instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData contributors(Action<ContributorContainer> action) {
+        Objects.requireNonNull(action);
+
+        contributors.configure(action);
+
+        return this;
+    }
+
+    /**
+     * @return The licenses currently configured on this meta data
+     * @since 0.2.0
+     */
+    public Collection<License> getLicenses() {
+        return licenses.getLicenses();
+    }
+
+    /**
+     * Overwrites the current licenses within this meta data with the provided collection
+     *
+     * @param licenses
+     *            A collection of licenses to set this meta data to
+     * @since 0.2.0
+     */
+    public void setLicenses(Collection<License> licenses) {
+        this.licenses.setLicenses(licenses);
+    }
+
+    /**
+     * Configures the licenses for the project via the specified action
+     *
+     * @param closure
+     *            A closure used to configure the licenses
+     * @return This meta data instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData licenses(Closure<LicenseContainer> closure) {
+        Objects.requireNonNull(closure);
+
+        licenses.configure(closure);
+
+        return this;
+    }
+
+    /**
+     * Configures the licenses for the project via the specified action
+     *
+     * @param action
+     *            An action used to configure the licenses
+     * @return This meta data instance, with the provided configuration applied
+     * @since 0.2.0
+     */
+    public ProjectMetaData licenses(Action<LicenseContainer> action) {
+        Objects.requireNonNull(action);
+
+        licenses.configure(action);
+
+        return this;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUrl(),
+                getScm(),
+                getDevelopers(),
+                getContributors(),
+                getLicenses());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof ProjectMetaData) {
+            ProjectMetaData compare = (ProjectMetaData) obj;
+
+            result = Objects.equals(compare.getUrl(), getUrl())
+                    && Objects.equals(compare.getScm(), getScm())
+                    && Objects.equals(compare.getDevelopers(), getDevelopers())
+                    && Objects.equals(compare.getContributors(), getContributors())
+                    && Objects.equals(compare.getLicenses(), getLicenses());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("url", getUrl())
+                .add("scm", getScm())
+                .add("developers", getDevelopers())
+                .add("contributors", getContributors())
+                .add("licenses", getLicenses())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Scm.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Scm.java
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.gradle.api.Action;
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import groovy.lang.Closure;
+
+/**
+ * Represents source control information for a repository
+ *
+ * <p>
+ * Based of Maven POM definition of a <a href="https://maven.apache.org/pom.html#SCM">SCM</a>
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class Scm {
+
+    private String vcsUrl;
+
+    private String connection;
+
+    private String developerConnection;
+
+    /**
+     * Initializes an empty SCM record
+     *
+     * @since 0.2.0
+     */
+    public Scm() {
+        this(null, null, null);
+    }
+
+    /**
+     * @param vcsUrl
+     *            URL for the version control system
+     * @param connection
+     *            Version control connection usable by contributors/consumers to obtain source code
+     * @param developerConnection
+     *            Version control connection usable by developers to obtain source code
+     * @since 0.2.0
+     */
+    public Scm(String vcsUrl, String connection, String developerConnection) {
+        this.vcsUrl = vcsUrl;
+        this.connection = connection;
+        this.developerConnection = developerConnection;
+    }
+
+    /**
+     * Allows external configuration of the scm. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param closure
+     *            Closure to configure the scm
+     * @return This (configured) scm
+     * @since 0.2.0
+     */
+    public Scm configure(Closure<Scm> closure) {
+        Objects.requireNonNull(closure);
+
+        closure.setDelegate(this);
+        closure.call();
+
+        return this;
+    }
+
+    /**
+     * Allows external configuration of the scm. Mainly used in Gradle DSLs (Groovy) for in-line configuration
+     *
+     * @param action
+     *            Action to configure the scm
+     * @return This (configured) scm
+     * @since 0.2.0
+     */
+    public Scm configure(Action<Scm> action) {
+        Objects.requireNonNull(action);
+
+        action.execute(this);
+
+        return this;
+    }
+
+    /**
+     * @return URL for the version control system
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getVcsUrl() {
+        return vcsUrl;
+    }
+
+    /**
+     * @param vcsUrl
+     *            URL for the version control system
+     * @since 0.2.0
+     */
+    public void setVcsUrl(@Nullable String vcsUrl) {
+        this.vcsUrl = vcsUrl;
+    }
+
+    /**
+     * @return Version control connection usable by contributors/consumers to obtain source code
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getConnection() {
+        return connection;
+    }
+
+    /**
+     * @param connection
+     *            Version control connection usable by contributors/consumers to obtain source code
+     * @since 0.2.0
+     */
+    public void setConnection(@Nullable String connection) {
+        this.connection = connection;
+    }
+
+    /**
+     * @return Version control connection usable by developers to obtain source code
+     * @since 0.2.0
+     */
+    @Nullable
+    public String getDeveloperConnection() {
+        return developerConnection;
+    }
+
+    /**
+     * @param developerConnection
+     *            Version control connection usable by developers to obtain source code
+     * @since 0.2.0
+     */
+    public void setDeveloperConnection(@Nullable String developerConnection) {
+        this.developerConnection = developerConnection;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getVcsUrl(),
+                getConnection(),
+                getDeveloperConnection());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof Scm) {
+            Scm compare = (Scm) obj;
+
+            result = Objects.equals(compare.getVcsUrl(), getVcsUrl())
+                    && Objects.equals(compare.getConnection(), getConnection())
+                    && Objects.equals(compare.getDeveloperConnection(), getDeveloperConnection());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("vcsUrl", getVcsUrl())
+                .add("connection", getConnection())
+                .add("developerConnection", getDeveloperConnection())
+                .toString();
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataBasePlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataBasePlugin.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.starchartlabs.flare.plugins.model.ProjectMetaData;
+
+/**
+ * Configuration plug-in that adds structures for defining project meta data which can be referenced throughout the
+ * build system, primarily as properties on published elements
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class MetaDataBasePlugin implements Plugin<Project> {
+
+    private static final String DSL_EXTENSION = "projectMetaData";
+
+    @Override
+    public void apply(Project project) {
+        project.getExtensions().add(DSL_EXTENSION, new ProjectMetaData());
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
@@ -7,14 +7,13 @@
 package org.starchartlabs.flare.plugins.plugin;
 
 import java.io.File;
-import java.io.IOException;
 
-import org.gradle.api.GradleException;
 import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.starchartlabs.flare.plugins.model.CredentialSet;
 import org.starchartlabs.flare.plugins.model.DependencyConstraints;
+import org.starchartlabs.flare.plugins.model.ProjectMetaData;
 
 /**
  * Plug-in that applies all Flare plug-ins applicable to StarChart Labs multi-module library configurations, and sets
@@ -34,17 +33,25 @@ public class MultiModuleLibraryPlugin implements Plugin<Project> {
             p.getPluginManager().apply("org.starchartlabs.flare.managed-credentials");
             p.getPluginManager().apply("org.starchartlabs.flare.increased-test-logging");
             p.getPluginManager().apply("org.starchartlabs.flare.source-jars");
+            p.getPluginManager().apply("org.starchartlabs.flare.metadata-base");
+
+            DependencyConstraints dependencyConstraints = p.getExtensions().getByType(DependencyConstraints.class);
+            ProjectMetaData projectMetaData = p.getExtensions().getByType(ProjectMetaData.class);
 
             File dependenciesFile = project.file(project.getProjectDir().toPath().resolve("dependencies.properties"));
+            File developersFile = project.file(project.getProjectDir().toPath().resolve("developers.properties"));
+            File contributorsFile = project.file(project.getProjectDir().toPath().resolve("contributors.properties"));
 
             if (dependenciesFile.exists()) {
-                try {
-                    DependencyConstraints dependencyConstraints = p.getExtensions()
-                            .getByType(DependencyConstraints.class);
-                    dependencyConstraints.file(dependenciesFile);
-                } catch (IOException e) {
-                    throw new GradleException("Error loading dependency properties", e);
-                }
+                dependencyConstraints.file(dependenciesFile);
+            }
+
+            if (developersFile.exists()) {
+                projectMetaData.github(gh -> gh.developers(developersFile));
+            }
+
+            if (contributorsFile.exists()) {
+                projectMetaData.github(gh -> gh.contributors(contributorsFile));
             }
 
             @SuppressWarnings("unchecked")

--- a/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.metadata-base.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.metadata-base.properties
@@ -1,0 +1,1 @@
+implementation-class=org.starchartlabs.flare.plugins.plugin.MetaDataBasePlugin

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorContrainerTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorContrainerTest.java
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.Contributor;
+import org.starchartlabs.flare.plugins.model.ContributorContainer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class ContributorContrainerTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new ContributorContainer().configure((Closure<ContributorContainer>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        ContributorContainer result = new ContributorContainer().configure(new TestClosure("name", "url"));
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new ContributorContainer().configure((Action<ContributorContainer>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        ContributorContainer result = new ContributorContainer().configure(container -> {
+            container.contributor("name", "url");
+        });
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test
+    public void contributorFields() throws Exception {
+        ContributorContainer result = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorClosureNullClosure() throws Exception {
+        new ContributorContainer().contributor((Closure<Contributor>) null);
+    }
+
+    @Test
+    public void coontributorClosure() throws Exception {
+        ContributorContainer result = new ContributorContainer()
+                .contributor(new TestContributorClosure("name", "url"));
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorActionNullAction() throws Exception {
+        new ContributorContainer().contributor((Action<Contributor>) null);
+    }
+
+    @Test
+    public void contributorAction() throws Exception {
+        ContributorContainer result = new ContributorContainer().contributor(contributor -> {
+            contributor.setName("name");
+            contributor.setUrl("url");
+        });
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        ContributorContainer result = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        ContributorContainer result1 = new ContributorContainer().contributor("name", "url");
+        ContributorContainer result2 = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        ContributorContainer result = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        ContributorContainer result = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        ContributorContainer result = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        ContributorContainer result1 = new ContributorContainer().contributor("name1", "url");
+        ContributorContainer result2 = new ContributorContainer().contributor("name2", "url");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        ContributorContainer result1 = new ContributorContainer().contributor("name", "url");
+        ContributorContainer result2 = new ContributorContainer().contributor("name", "url");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        ContributorContainer obj = new ContributorContainer().contributor("name", "url");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("contributors"));
+        Assert.assertTrue(result.contains("name=name"));
+        Assert.assertTrue(result.contains("url=url"));
+    }
+
+    private static class TestClosure extends Closure<ContributorContainer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String url;
+
+        public TestClosure(String name, String url) {
+            super(null);
+
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public ContributorContainer call() {
+            ((ContributorContainer) getDelegate()).contributor(name, url);
+
+            return ((ContributorContainer) getDelegate());
+        }
+
+    }
+
+    private static class TestContributorClosure extends Closure<Contributor> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String url;
+
+        public TestContributorClosure(String name, String url) {
+            super(null);
+
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public Contributor call() {
+            ((Contributor) getDelegate()).setName(name);
+            ((Contributor) getDelegate()).setUrl(url);
+
+            return ((Contributor) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.Contributor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class ContributorTest {
+
+    @Test
+    public void constructNullName() throws Exception {
+        Contributor result = new Contributor(null, "url");
+
+        Assert.assertNull(result.getName());
+    }
+
+    @Test
+    public void constructNullUrl() throws Exception {
+        Contributor result = new Contributor("name", null);
+
+        Assert.assertNull(result.getUrl());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new Contributor("name", "url").configure((Closure<Contributor>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        Contributor result = new Contributor().configure(new TestClosure("name", "url"));
+
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new Contributor("name", "url").configure((Action<Contributor>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        Contributor result = new Contributor().configure(contributor -> {
+            contributor.setName("name");
+            contributor.setUrl("url");
+        });
+
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        Contributor result = new Contributor("name", "url");
+
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        Contributor result1 = new Contributor("name", "url");
+        Contributor result2 = new Contributor("name", "url");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        Contributor result = new Contributor("name", "url");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        Contributor result = new Contributor("name", "url");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        Contributor result = new Contributor("name", "url");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        Contributor result1 = new Contributor("name1", "url");
+        Contributor result2 = new Contributor("name2", "url");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        Contributor result1 = new Contributor("name", "url");
+        Contributor result2 = new Contributor("name", "url");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Contributor obj = new Contributor("name", "url");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("name=name"));
+        Assert.assertTrue(result.contains("url=url"));
+    }
+
+    private static class TestClosure extends Closure<Contributor> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String url;
+
+        public TestClosure(String name, String url) {
+            super(null);
+
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public Contributor call() {
+            ((Contributor) getDelegate()).setName(name);
+            ((Contributor) getDelegate()).setUrl(url);
+
+            return ((Contributor) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperContainerTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperContainerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.Developer;
+import org.starchartlabs.flare.plugins.model.DeveloperContainer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class DeveloperContainerTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new DeveloperContainer().configure((Closure<DeveloperContainer>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().configure(new TestClosure("id", "name", "url"));
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new DeveloperContainer().configure((Action<DeveloperContainer>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().configure(container -> {
+            container.developer("id", "name", "url");
+        });
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test
+    public void contributorFields() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorClosureNullClosure() throws Exception {
+        new DeveloperContainer().developer((Closure<Developer>) null);
+    }
+
+    @Test
+    public void coontributorClosure() throws Exception {
+        DeveloperContainer result = new DeveloperContainer()
+                .developer(new TestDeveloperClosure("id", "name", "url"));
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorActionNullAction() throws Exception {
+        new DeveloperContainer().developer((Action<Developer>) null);
+    }
+
+    @Test
+    public void contributorAction() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().developer(developer -> {
+            developer.setId("id");
+            developer.setName("name");
+            developer.setUrl("url");
+        });
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        DeveloperContainer result1 = new DeveloperContainer().developer("id", "name", "url");
+        DeveloperContainer result2 = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        DeveloperContainer result = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        DeveloperContainer result1 = new DeveloperContainer().developer("id1", "name", "url");
+        DeveloperContainer result2 = new DeveloperContainer().developer("id2", "name", "url");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        DeveloperContainer result1 = new DeveloperContainer().developer("id", "name", "url");
+        DeveloperContainer result2 = new DeveloperContainer().developer("id", "name", "url");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        DeveloperContainer obj = new DeveloperContainer().developer("id", "name", "url");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("developers"));
+        Assert.assertTrue(result.contains("id=id"));
+        Assert.assertTrue(result.contains("name=name"));
+        Assert.assertTrue(result.contains("url=url"));
+    }
+
+    private static class TestClosure extends Closure<DeveloperContainer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String id;
+
+        private final String name;
+
+        private final String url;
+
+        public TestClosure(String id, String name, String url) {
+            super(null);
+
+            this.id = id;
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public DeveloperContainer call() {
+            ((DeveloperContainer) getDelegate()).developer(id, name, url);
+
+            return ((DeveloperContainer) getDelegate());
+        }
+
+    }
+
+    private static class TestDeveloperClosure extends Closure<Developer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String id;
+
+        private final String name;
+
+        private final String url;
+
+        public TestDeveloperClosure(String id, String name, String url) {
+            super(null);
+
+            this.id = id;
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public Developer call() {
+            ((Developer) getDelegate()).setId(id);
+            ((Developer) getDelegate()).setName(name);
+            ((Developer) getDelegate()).setUrl(url);
+
+            return ((Developer) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.Developer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class DeveloperTest {
+
+    @Test
+    public void constructNullId() throws Exception {
+        Developer result = new Developer(null, "name", "url");
+
+        Assert.assertNull(result.getId());
+    }
+
+    @Test
+    public void constructNullName() throws Exception {
+        Developer result = new Developer("id", null, "url");
+
+        Assert.assertNull(result.getName());
+    }
+
+    @Test
+    public void constructNullUrl() throws Exception {
+        Developer result = new Developer("id", "name", null);
+
+        Assert.assertNull(result.getUrl());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new Developer().configure((Closure<Developer>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        Developer result = new Developer().configure(new TestClosure("id", "name", "url"));
+
+        Assert.assertEquals(result.getId(), "id");
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new Developer().configure((Action<Developer>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        Developer result = new Developer().configure(developer -> {
+            developer.setId("id");
+            developer.setName("name");
+            developer.setUrl("url");
+        });
+
+        Assert.assertEquals(result.getId(), "id");
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        Developer result = new Developer("id", "name", "url");
+
+        Assert.assertEquals(result.getId(), "id");
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        Developer result1 = new Developer("id", "name", "url");
+        Developer result2 = new Developer("id", "name", "url");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        Developer result = new Developer("id", "name", "url");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        Developer result = new Developer("id", "name", "url");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        Developer result = new Developer("id", "name", "url");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        Developer result1 = new Developer("id1", "name", "url");
+        Developer result2 = new Developer("id2", "name", "url");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        Developer result1 = new Developer("id", "name", "url");
+        Developer result2 = new Developer("id", "name", "url");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Developer obj = new Developer("id", "name", "url");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("id=id"));
+        Assert.assertTrue(result.contains("name=name"));
+        Assert.assertTrue(result.contains("url=url"));
+    }
+
+    private static class TestClosure extends Closure<Developer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String id;
+
+        private final String name;
+
+        private final String url;
+
+        public TestClosure(String id, String name, String url) {
+            super(null);
+
+            this.id = id;
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public Developer call() {
+            ((Developer) getDelegate()).setId(id);
+            ((Developer) getDelegate()).setName(name);
+            ((Developer) getDelegate()).setUrl(url);
+
+            return ((Developer) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/GitHubMetaDataTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/GitHubMetaDataTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Arrays;
+
+import org.starchartlabs.flare.plugins.model.Contributor;
+import org.starchartlabs.flare.plugins.model.Developer;
+import org.starchartlabs.flare.plugins.model.GitHubMetaData;
+import org.starchartlabs.flare.plugins.model.ProjectMetaData;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class GitHubMetaDataTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullDelegate() throws Exception {
+        new GitHubMetaData(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void repositoryNullOwner() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).repository(null, "repository");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void repositoryNullRepository() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).repository("owner", null);
+    }
+
+    @Test
+    public void repository() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).repository("owner", "repository");
+
+        Assert.assertEquals(delegate.getUrl(), "https://github.com/owner/repository");
+
+        Assert.assertEquals(delegate.getScm().getVcsUrl(), "https://github.com/owner/repository");
+        Assert.assertEquals(delegate.getScm().getConnection(), "scm:git:git://github.com/owner/repository.git");
+        Assert.assertEquals(delegate.getScm().getDeveloperConnection(),
+                "scm:git:ssh://github.com/owner/repository.git");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void developerUsernameOnlyNullUsername() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developer(null);
+    }
+
+    @Test
+    public void developerUsernameOnly() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developer("username");
+
+        Assert.assertEquals(delegate.getDevelopers().size(), 1);
+        Assert.assertTrue(delegate.getDevelopers()
+                .contains(new Developer("username", "username", "https://github.com/username")));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void developerNullUsername() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developer(null, "name");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void developerNullName() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developer("username", null);
+    }
+
+    @Test
+    public void developer() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developer("username", "name");
+
+        Assert.assertEquals(delegate.getDevelopers().size(), 1);
+        Assert.assertTrue(delegate.getDevelopers()
+                .contains(new Developer("username", "name", "https://github.com/username")));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void developersNullFile() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developers(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void developersFileDoesntExist() throws Exception {
+        File file = Paths.get("nope").toFile();
+
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developers(file);
+    }
+
+    @Test
+    public void developers() throws Exception {
+        Path developersFile = Files.createTempFile("developers", ".proprties");
+        developersFile.toFile().deleteOnExit();
+
+        Files.write(developersFile, Arrays.asList("usernameonly", "username, name"));
+
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).developers(developersFile.toFile());
+
+        Assert.assertEquals(delegate.getDevelopers().size(), 2);
+        Assert.assertTrue(delegate.getDevelopers()
+                .contains(new Developer("usernameonly", "usernameonly", "https://github.com/usernameonly")));
+        Assert.assertTrue(delegate.getDevelopers()
+                .contains(new Developer("username", "name", "https://github.com/username")));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorUsernameOnlyNullUsername() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributor(null);
+    }
+
+    @Test
+    public void contributorUsernameOnly() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributor("username");
+
+        Assert.assertEquals(delegate.getContributors().size(), 1);
+        Assert.assertTrue(
+                delegate.getContributors().contains(new Contributor("username", "https://github.com/username")));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorNullUsername() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributor(null, "name");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorNullName() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributor("username", null);
+    }
+
+    @Test
+    public void contributor() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributor("username", "name");
+
+        Assert.assertEquals(delegate.getContributors().size(), 1);
+        Assert.assertTrue(delegate.getContributors().contains(new Contributor("name", "https://github.com/username")));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorsNullFile() throws Exception {
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributors(null);
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class)
+    public void contributorsFileDoesntExist() throws Exception {
+        File file = Paths.get("nope").toFile();
+
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributors(file);
+    }
+
+    @Test
+    public void contributors() throws Exception {
+        Path contributorsFile = Files.createTempFile("contributors", ".proprties");
+        contributorsFile.toFile().deleteOnExit();
+
+        Files.write(contributorsFile, Arrays.asList("usernameonly", "username, name"));
+
+        ProjectMetaData delegate = new ProjectMetaData();
+
+        new GitHubMetaData(delegate).contributors(contributorsFile.toFile());
+
+        Assert.assertEquals(delegate.getContributors().size(), 2);
+        Assert.assertTrue(delegate.getContributors()
+                .contains(new Contributor("usernameonly", "https://github.com/usernameonly")));
+        Assert.assertTrue(delegate.getContributors()
+                .contains(new Contributor("name", "https://github.com/username")));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseContainerTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseContainerTest.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.License;
+import org.starchartlabs.flare.plugins.model.LicenseContainer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class LicenseContainerTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new LicenseContainer().configure((Closure<LicenseContainer>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        LicenseContainer result = new LicenseContainer()
+                .configure(new TestClosure("name", "tag", "url", "distribution"));
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new LicenseContainer().configure((Action<LicenseContainer>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        LicenseContainer result = new LicenseContainer()
+                .configure(container -> container.license("name", "tag", "url", "distribution"));
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test
+    public void licenseFields() throws Exception {
+        LicenseContainer result = new LicenseContainer().license("name", "tag", "url", "distribution");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void licenseClosureNullClosure() throws Exception {
+        new LicenseContainer().license((Closure<License>) null);
+    }
+
+    @Test
+    public void licenseClosure() throws Exception {
+        LicenseContainer result = new LicenseContainer()
+                .license(new TestLicenseClosure("name", "tag", "url", "distribution"));
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void licenseActionNullAction() throws Exception {
+        new LicenseContainer().license((Action<License>) null);
+    }
+
+    @Test
+    public void licenseAction() throws Exception {
+        LicenseContainer result = new LicenseContainer().license(license -> {
+            license.setName("name");
+            license.setTag("tag");
+            license.setUrl("url");
+            license.setDistribution("distribution");
+        });
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test
+    public void apache2() throws Exception {
+        LicenseContainer result = new LicenseContainer().apache2();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(),
+                new License("The Apache Software License, Version 2.0", "Apache 2.0",
+                        "http://www.apache.org/licenses/LICENSE-2.0.txt", "repo"));
+    }
+
+    @Test
+    public void apache2CustomDistribution() throws Exception {
+        LicenseContainer result = new LicenseContainer().apache2("distribution");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(),
+                new License("The Apache Software License, Version 2.0", "Apache 2.0",
+                        "http://www.apache.org/licenses/LICENSE-2.0.txt", "distribution"));
+    }
+
+    @Test
+    public void mit() throws Exception {
+        LicenseContainer result = new LicenseContainer().mit();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(),
+                new License("The MIT License", "MIT", "https://opensource.org/licenses/MIT", "repo"));
+    }
+
+    @Test
+    public void mitCustomDistribution() throws Exception {
+        LicenseContainer result = new LicenseContainer().mit("distribution");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(),
+                new License("The MIT License", "MIT", "https://opensource.org/licenses/MIT", "distribution"));
+    }
+
+    @Test
+    public void epl() throws Exception {
+        LicenseContainer result = new LicenseContainer().epl();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(),
+                new License("Eclipse Public License 1.0", "EPL", "https://opensource.org/licenses/EPL-1.0", "repo"));
+    }
+
+    @Test
+    public void eplCustomDistribution() throws Exception {
+        LicenseContainer result = new LicenseContainer().epl("distribution");
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(),
+                new License("Eclipse Public License 1.0", "EPL", "https://opensource.org/licenses/EPL-1.0",
+                        "distribution"));
+    }
+
+    private static class TestClosure extends Closure<LicenseContainer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String tag;
+
+        private final String url;
+
+        private final String distribution;
+
+        public TestClosure(String name, String tag, String url, String distribution) {
+            super(null);
+
+            this.name = name;
+            this.tag = tag;
+            this.url = url;
+            this.distribution = distribution;
+        }
+
+        @Override
+        public LicenseContainer call() {
+            ((LicenseContainer) getDelegate()).license(name, tag, url, distribution);
+
+            return ((LicenseContainer) getDelegate());
+        }
+
+    }
+
+    private static class TestLicenseClosure extends Closure<License> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String tag;
+
+        private final String url;
+
+        private final String distribution;
+
+        public TestLicenseClosure(String name, String tag, String url, String distribution) {
+            super(null);
+
+            this.name = name;
+            this.tag = tag;
+            this.url = url;
+            this.distribution = distribution;
+        }
+
+        @Override
+        public License call() {
+            ((License) getDelegate()).setName(name);
+            ((License) getDelegate()).setTag(tag);
+            ((License) getDelegate()).setUrl(url);
+            ((License) getDelegate()).setDistribution(distribution);
+
+            return ((License) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.License;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class LicenseTest {
+
+    @Test
+    public void constructNullName() throws Exception {
+        License result = new License(null, "tag", "url", "distribution");
+
+        Assert.assertNull(result.getName());
+    }
+
+    @Test
+    public void constructNullTag() throws Exception {
+        License result = new License("name", null, "url", "distribution");
+
+        Assert.assertNull(result.getTag());
+    }
+
+    @Test
+    public void constructNullUrl() throws Exception {
+        License result = new License("name", "tag", null, "distribution");
+
+        Assert.assertNull(result.getUrl());
+    }
+
+    @Test
+    public void constructNullDistribution() throws Exception {
+        License result = new License("name", "tag", "url", null);
+
+        Assert.assertNull(result.getDistribution());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new License().configure((Closure<License>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        License result = new License().configure(new TestClosure("name", "tag", "url", "distribution"));
+
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getTag(), "tag");
+        Assert.assertEquals(result.getUrl(), "url");
+        Assert.assertEquals(result.getDistribution(), "distribution");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new License().configure((Action<License>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        License result = new License().configure(license -> {
+            license.setName("name");
+            license.setTag("tag");
+            license.setUrl("url");
+            license.setDistribution("distribution");
+        });
+
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getTag(), "tag");
+        Assert.assertEquals(result.getUrl(), "url");
+        Assert.assertEquals(result.getDistribution(), "distribution");
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        License result = new License("name", "tag", "url", "distribution");
+
+        Assert.assertEquals(result.getName(), "name");
+        Assert.assertEquals(result.getTag(), "tag");
+        Assert.assertEquals(result.getUrl(), "url");
+        Assert.assertEquals(result.getDistribution(), "distribution");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        License result1 = new License("name", "tag", "url", "distribution");
+        License result2 = new License("name", "tag", "url", "distribution");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        License result = new License("name", "tag", "url", "distribution");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        License result = new License("name", "tag", "url", "distribution");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        License result = new License("name", "tag", "url", "distribution");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        License result1 = new License("name1", "tag", "url", "distribution");
+        License result2 = new License("name2", "tag", "url", "distribution");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        License result1 = new License("name", "tag", "url", "distribution");
+        License result2 = new License("name", "tag", "url", "distribution");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        License obj = new License("name", "tag", "url", "distribution");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("name=name"));
+        Assert.assertTrue(result.contains("tag=tag"));
+        Assert.assertTrue(result.contains("url=url"));
+        Assert.assertTrue(result.contains("distribution=distribution"));
+    }
+
+    private static class TestClosure extends Closure<License> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String tag;
+
+        private final String url;
+
+        private final String distribution;
+
+        public TestClosure(String name, String tag, String url, String distribution) {
+            super(null);
+
+            this.name = name;
+            this.tag = tag;
+            this.url = url;
+            this.distribution = distribution;
+        }
+
+        @Override
+        public License call() {
+            ((License) getDelegate()).setName(name);
+            ((License) getDelegate()).setTag(tag);
+            ((License) getDelegate()).setUrl(url);
+            ((License) getDelegate()).setDistribution(distribution);
+
+            return ((License) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ProjectMetaDataTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ProjectMetaDataTest.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.Contributor;
+import org.starchartlabs.flare.plugins.model.ContributorContainer;
+import org.starchartlabs.flare.plugins.model.Developer;
+import org.starchartlabs.flare.plugins.model.DeveloperContainer;
+import org.starchartlabs.flare.plugins.model.GitHubMetaData;
+import org.starchartlabs.flare.plugins.model.License;
+import org.starchartlabs.flare.plugins.model.LicenseContainer;
+import org.starchartlabs.flare.plugins.model.ProjectMetaData;
+import org.starchartlabs.flare.plugins.model.Scm;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class ProjectMetaDataTest {
+
+    private static final Scm SCM = new Scm("vcsUrl", "connection", "developerConnection");
+
+    private static final DeveloperContainer DEVELOPERS = new DeveloperContainer().developer("id", "name", "url");
+
+    private static final ContributorContainer CONTRIBUTORS = new ContributorContainer().contributor("name", "url");
+
+    private static final LicenseContainer LICENSES = new LicenseContainer().license("name", "tag", "url",
+            "distribution");
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void githubClosureNullClosure() throws Exception {
+        new ProjectMetaData().github((Closure<GitHubMetaData>) null);
+    }
+
+    @Test
+    public void githubClosure() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .github(new TestGitHubMetaDataClosure("owner", "repository"));
+
+        Assert.assertEquals(result.getUrl(), "https://github.com/owner/repository");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void githubActionNullAction() throws Exception {
+        new ProjectMetaData().github((Action<GitHubMetaData>) null);
+    }
+
+    @Test
+    public void githubAction() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .github(githubMeta -> githubMeta.repository("owner", "repository"));
+
+        Assert.assertEquals(result.getUrl(), "https://github.com/owner/repository");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void scmClosureNullClosure() throws Exception {
+        new ProjectMetaData().scm((Closure<Scm>) null);
+    }
+
+    @Test
+    public void scmClosure() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .scm(new TestScmClosure("vcsUrl"));
+
+        Assert.assertEquals(result.getScm().getVcsUrl(), "vcsUrl");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void scmActionNullAction() throws Exception {
+        new ProjectMetaData().scm((Action<Scm>) null);
+    }
+
+    @Test
+    public void scmAction() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .scm(s -> s.setVcsUrl("vcsUrl"));
+
+        Assert.assertEquals(result.getScm().getVcsUrl(), "vcsUrl");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void setScmNullScm() throws Exception {
+        new ProjectMetaData().setScm(null);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void developersClosureNullClosure() throws Exception {
+        new ProjectMetaData().developers((Closure<DeveloperContainer>) null);
+    }
+
+    @Test
+    public void developersClosure() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .developers(new TestDevelopersClosure("id", "name", "url"));
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void developersActionNullAction() throws Exception {
+        new ProjectMetaData().developers((Action<DeveloperContainer>) null);
+    }
+
+    @Test
+    public void developersAction() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .developers(devs -> devs.developer("id", "name", "url"));
+
+        Assert.assertEquals(result.getDevelopers().size(), 1);
+        Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorsClosureNullClosure() throws Exception {
+        new ProjectMetaData().contributors((Closure<ContributorContainer>) null);
+    }
+
+    @Test
+    public void contributorsClosure() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .contributors(new TestContributorsClosure("name", "url"));
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void contributorsActionNullAction() throws Exception {
+        new ProjectMetaData().contributors((Action<ContributorContainer>) null);
+    }
+
+    @Test
+    public void contributorsAction() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .contributors(contribs -> contribs.contributor("name", "url"));
+
+        Assert.assertEquals(result.getContributors().size(), 1);
+        Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void licensesClosureNullClosure() throws Exception {
+        new ProjectMetaData().licenses((Closure<LicenseContainer>) null);
+    }
+
+    @Test
+    public void licensesClosure() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .licenses(new TestLicensesClosure("name", "tag", "url", "distribution"));
+
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void licensesActionNullAction() throws Exception {
+        new ProjectMetaData().licenses((Action<LicenseContainer>) null);
+    }
+
+    @Test
+    public void licensesAction() throws Exception {
+        ProjectMetaData result = new ProjectMetaData()
+                .licenses(lics -> lics.license("name", "tag", "url", "distribution"));
+
+        Assert.assertEquals(result.getLicenses().size(), 1);
+        Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        ProjectMetaData result = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertEquals(result.getUrl(), "url");
+        Assert.assertEquals(result.getScm(), SCM);
+        Assert.assertEquals(result.getDevelopers(), DEVELOPERS.getDevelopers());
+        Assert.assertEquals(result.getContributors(), CONTRIBUTORS.getContributors());
+        Assert.assertEquals(result.getLicenses(), LICENSES.getLicenses());
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        ProjectMetaData result1 = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+        ProjectMetaData result2 = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        ProjectMetaData result = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        ProjectMetaData result = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        ProjectMetaData result = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        ProjectMetaData result1 = new ProjectMetaData("url1", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+        ProjectMetaData result2 = new ProjectMetaData("url2", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        ProjectMetaData result1 = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+        ProjectMetaData result2 = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        ProjectMetaData obj = new ProjectMetaData("url", SCM, DEVELOPERS, CONTRIBUTORS, LICENSES);
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("url=url"));
+        Assert.assertTrue(result.contains("scm=" + SCM.toString()));
+        Assert.assertTrue(result.contains("developers=" + DEVELOPERS.getDevelopers().toString()));
+        Assert.assertTrue(result.contains("contributors=" + CONTRIBUTORS.getContributors().toString()));
+        Assert.assertTrue(result.contains("licenses=" + LICENSES.getLicenses().toString()));
+    }
+
+    private static final class TestGitHubMetaDataClosure extends Closure<GitHubMetaData> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String owner;
+
+        private final String repository;
+
+        public TestGitHubMetaDataClosure(String owner, String repository) {
+            super(null);
+
+            this.owner = owner;
+            this.repository = repository;
+        }
+
+        @Override
+        public GitHubMetaData call() {
+            ((GitHubMetaData) getDelegate()).repository(owner, repository);
+
+            return ((GitHubMetaData) getDelegate());
+        }
+
+    }
+
+    private static final class TestScmClosure extends Closure<Scm> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String vcsUrl;
+
+        public TestScmClosure(String vcsUrl) {
+            super(null);
+
+            this.vcsUrl = vcsUrl;
+        }
+
+        @Override
+        public Scm call() {
+            ((Scm) getDelegate()).setVcsUrl(vcsUrl);
+
+            return ((Scm) getDelegate());
+        }
+
+    }
+
+    private static final class TestDevelopersClosure extends Closure<DeveloperContainer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String id;
+
+        private final String name;
+
+        private final String url;
+
+        public TestDevelopersClosure(String id, String name, String url) {
+            super(null);
+
+            this.id = id;
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public DeveloperContainer call() {
+            ((DeveloperContainer) getDelegate()).developer(id, name, url);
+
+            return ((DeveloperContainer) getDelegate());
+        }
+
+    }
+
+    private static final class TestContributorsClosure extends Closure<ContributorContainer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String url;
+
+        public TestContributorsClosure(String name, String url) {
+            super(null);
+
+            this.name = name;
+            this.url = url;
+        }
+
+        @Override
+        public ContributorContainer call() {
+            ((ContributorContainer) getDelegate()).contributor(name, url);
+
+            return ((ContributorContainer) getDelegate());
+        }
+
+    }
+
+    private static final class TestLicensesClosure extends Closure<LicenseContainer> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String name;
+
+        private final String tag;
+
+        private final String url;
+
+        private final String distribution;
+
+        public TestLicensesClosure(String name, String tag, String url, String distribution) {
+            super(null);
+
+            this.name = name;
+            this.tag = tag;
+            this.url = url;
+            this.distribution = distribution;
+        }
+
+        @Override
+        public LicenseContainer call() {
+            ((LicenseContainer) getDelegate()).license(name, tag, url, distribution);
+
+            return ((LicenseContainer) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ScmTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ScmTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.gradle.api.Action;
+import org.starchartlabs.flare.plugins.model.Scm;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import groovy.lang.Closure;
+
+public class ScmTest {
+
+    @Test
+    public void constructNullVcsUrl() throws Exception {
+        Scm result = new Scm(null, "connection", "developerConnection");
+
+        Assert.assertNull(result.getVcsUrl());
+    }
+
+    @Test
+    public void constructNullConnection() throws Exception {
+        Scm result = new Scm("vcsUrl", null, "developerConnection");
+
+        Assert.assertNull(result.getConnection());
+    }
+
+    @Test
+    public void constructNullDeveloperConnection() throws Exception {
+        Scm result = new Scm("vcsUrl", "connection", null);
+
+        Assert.assertNull(result.getDeveloperConnection());
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureClosureNullClosure() throws Exception {
+        new Scm().configure((Closure<Scm>) null);
+    }
+
+    @Test
+    public void configureClosure() throws Exception {
+        Scm result = new Scm().configure(new TestClosure("vcsUrl", "connection", "developerConnection"));
+
+        Assert.assertEquals(result.getVcsUrl(), "vcsUrl");
+        Assert.assertEquals(result.getConnection(), "connection");
+        Assert.assertEquals(result.getDeveloperConnection(), "developerConnection");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void configureActionNullAction() throws Exception {
+        new Scm().configure((Action<Scm>) null);
+    }
+
+    @Test
+    public void configureAction() throws Exception {
+        Scm result = new Scm().configure(scm -> {
+            scm.setVcsUrl("vcsUrl");
+            scm.setConnection("connection");
+            scm.setDeveloperConnection("developerConnection");
+        });
+
+        Assert.assertEquals(result.getVcsUrl(), "vcsUrl");
+        Assert.assertEquals(result.getConnection(), "connection");
+        Assert.assertEquals(result.getDeveloperConnection(), "developerConnection");
+    }
+
+    @Test
+    public void getTest() throws Exception {
+        Scm result = new Scm("vcsUrl", "connection", "developerConnection");
+
+        Assert.assertEquals(result.getVcsUrl(), "vcsUrl");
+        Assert.assertEquals(result.getConnection(), "connection");
+        Assert.assertEquals(result.getDeveloperConnection(), "developerConnection");
+    }
+
+    @Test
+    public void hashCodeEqualWhenDataEqual() throws Exception {
+        Scm result1 = new Scm("vcsUrl", "connection", "developerConnection");
+        Scm result2 = new Scm("vcsUrl", "connection", "developerConnection");
+
+        Assert.assertEquals(result1.hashCode(), result2.hashCode());
+    }
+
+    @Test
+    public void equalsNull() throws Exception {
+        Scm result = new Scm("vcsUrl", "connection", "developerConnection");
+
+        Assert.assertFalse(result.equals(null));
+    }
+
+    // Test is specifically for the mis-matched type case - warning is invalid
+    @Test
+    @SuppressWarnings("unlikely-arg-type")
+    public void equalsDifferentClass() throws Exception {
+        Scm result = new Scm("vcsUrl", "connection", "developerConnection");
+
+        Assert.assertFalse(result.equals("string"));
+    }
+
+    @Test
+    public void equalsSelf() throws Exception {
+        Scm result = new Scm("vcsUrl", "connection", "developerConnection");
+
+        Assert.assertTrue(result.equals(result));
+    }
+
+    @Test
+    public void equalsDifferentData() throws Exception {
+        Scm result1 = new Scm("vcsUrl1", "connection", "developerConnection");
+        Scm result2 = new Scm("vcsUrl2", "connection", "developerConnection");
+
+        Assert.assertFalse(result1.equals(result2));
+    }
+
+    @Test
+    public void equalsSameData() throws Exception {
+        Scm result1 = new Scm("vcsUrl", "connection", "developerConnection");
+        Scm result2 = new Scm("vcsUrl", "connection", "developerConnection");
+
+        Assert.assertTrue(result1.equals(result2));
+    }
+
+    @Test
+    public void toStringTest() throws Exception {
+        Scm obj = new Scm("vcsUrl", "connection", "developerConnection");
+
+        String result = obj.toString();
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(result.contains("vcsUrl=vcsUrl"));
+        Assert.assertTrue(result.contains("connection=connection"));
+        Assert.assertTrue(result.contains("developerConnection=developerConnection"));
+    }
+
+    private static class TestClosure extends Closure<Scm> {
+
+        private static final long serialVersionUID = 1L;
+
+        private final String vcsUrl;
+
+        private final String connection;
+
+        private final String developerConnection;
+
+        public TestClosure(String vcsUrl, String connection, String developerConnection) {
+            super(null);
+
+            this.vcsUrl = vcsUrl;
+            this.connection = connection;
+            this.developerConnection = developerConnection;
+        }
+
+        @Override
+        public Scm call() {
+            ((Scm) getDelegate()).setVcsUrl(vcsUrl);
+            ((Scm) getDelegate()).setConnection(connection);
+            ((Scm) getDelegate()).setDeveloperConnection(developerConnection);
+
+            return ((Scm) getDelegate());
+        }
+
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataBasePluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataBasePluginIntegrationTest.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.starchartlabs.alloy.core.Strings;
+import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.starchartlabs.flare.plugins.test.TestGradleProject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(value = { IntegrationTestListener.class })
+public class MetaDataBasePluginIntegrationTest {
+
+    private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
+            "metadata", "base");
+
+    private static final Path STANDARD_SETUP_FILE = BUILD_FILE_DIRECTORY.resolve("standardSetup.gradle");
+
+    private static final Path GITHUB_SETUP_FILE = BUILD_FILE_DIRECTORY.resolve("githubSetup.gradle");
+
+    private Path standardSetupProjectPath;
+
+    private Path githubSetupProjectPath;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        standardSetupProjectPath = TestGradleProject.builder(STANDARD_SETUP_FILE)
+                .build()
+                .getProjectDirectory();
+
+        githubSetupProjectPath = TestGradleProject.builder(GITHUB_SETUP_FILE)
+                .addFile(BUILD_FILE_DIRECTORY.resolve("developers.properties"), Paths.get("developers.properties"))
+                .addFile(BUILD_FILE_DIRECTORY.resolve("contributors.properties"), Paths.get("contributors.properties"))
+                .build()
+                .getProjectDirectory();
+    }
+
+    @Test
+    public void standardSetup() throws Exception {
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(standardSetupProjectPath.toFile())
+                .withArguments("metaDataPrintout")
+                .withGradleVersion("5.0")
+                .build();
+
+        Collection<String> expectedLines = new ArrayList<>();
+        expectedLines.add("url: http://url");
+
+        expectedLines.add("scm.vcsUrl: http://scm/url");
+        expectedLines.add("scm.connection: scm/connection");
+        expectedLines.add("scm.developerConnection: scm/developerConnection");
+
+        expectedLines.add("developer: developer/id:developer/name:developer/url");
+
+        expectedLines.add("contributor: contributor/name:contributor/url");
+
+        expectedLines.add("license: license/name:license/tag:license/url:license/distribution");
+        expectedLines.add("license: The Apache Software License, Version 2.0:Apache 2.0"
+                + ":http://www.apache.org/licenses/LICENSE-2.0.txt:repo");
+        expectedLines.add("license: The MIT License:MIT:https://opensource.org/licenses/MIT:mit/distribution");
+        expectedLines.add(
+                "license: Eclipse Public License 1.0:EPL:https://opensource.org/licenses/EPL-1.0:epl/distribution");
+
+        for (String expectedLine : expectedLines) {
+            Assert.assertTrue(result.getOutput().contains(expectedLine),
+                    Strings.format("Did not find expected line '%s'", expectedLine));
+        }
+
+        TaskOutcome outcome = result.task(":metaDataPrintout").getOutcome();
+        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
+    }
+
+    @Test
+    public void githubSetup() throws Exception {
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(githubSetupProjectPath.toFile())
+                .withArguments("metaDataPrintout")
+                .withGradleVersion("5.0")
+                .build();
+
+        Collection<String> expectedLines = new ArrayList<>();
+        expectedLines.add("url: https://github.com/owner/repository");
+
+        expectedLines.add("scm.vcsUrl: https://github.com/owner/repository");
+        expectedLines.add("scm.connection: scm:git:git://github.com/owner/repository.git");
+        expectedLines.add("scm.developerConnection: scm:git:ssh://github.com/owner/repository.git");
+
+        expectedLines.add("developer: dev-usernameonly:dev-usernameonly:https://github.com/dev-usernameonly");
+        expectedLines.add("developer: dev-username:dev-name:https://github.com/dev-username");
+        expectedLines
+        .add("developer: dev-file-usernameonly:dev-file-usernameonly:https://github.com/dev-file-usernameonly");
+        expectedLines.add("developer: dev-file-username:dev-file-name:https://github.com/dev-file-username");
+
+        expectedLines.add("contributor: contrib-usernameonly:https://github.com/contrib-usernameonly");
+        expectedLines.add("contributor: contrib-name:https://github.com/contrib-username");
+        expectedLines.add("contributor: contrib-file-usernameonly:https://github.com/contrib-file-usernameonly");
+        expectedLines.add("contributor: contrib-file-name:https://github.com/contrib-file-username");
+
+        expectedLines.add("license: license/name:license/tag:license/url:license/distribution");
+        expectedLines.add("license: The Apache Software License, Version 2.0:Apache 2.0"
+                + ":http://www.apache.org/licenses/LICENSE-2.0.txt:repo");
+        expectedLines.add("license: The MIT License:MIT:https://opensource.org/licenses/MIT:mit/distribution");
+        expectedLines.add(
+                "license: Eclipse Public License 1.0:EPL:https://opensource.org/licenses/EPL-1.0:epl/distribution");
+
+        for (String expectedLine : expectedLines) {
+            Assert.assertTrue(result.getOutput().contains(expectedLine),
+                    Strings.format("Did not find expected line '%s'", expectedLine));
+        }
+
+        TaskOutcome outcome = result.task(":metaDataPrintout").getOutcome();
+        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataBasePluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataBasePluginTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.starchartlabs.flare.plugins.model.ProjectMetaData;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class MetaDataBasePluginTest {
+
+    private static final String PLUGIN_ID = "org.starchartlabs.flare.metadata-base";
+
+    private Project project;
+
+    @BeforeClass
+    public void setupProject() {
+        project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(PLUGIN_ID);
+    }
+
+    @Test
+    public void configurationApplied() throws Exception {
+        Object found = project.getExtensions().findByName("projectMetaData");
+
+        Assert.assertNotNull(found);
+        Assert.assertTrue(found instanceof ProjectMetaData);
+    }
+
+}

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/contributors.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/contributors.properties
@@ -1,0 +1,4 @@
+# Comment
+
+contrib-file-usernameonly
+contrib-file-username, contrib-file-name

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/developers.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/developers.properties
@@ -1,0 +1,4 @@
+# Comment
+
+dev-file-usernameonly
+dev-file-username, dev-file-name

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/githubSetup.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/githubSetup.gradle
@@ -1,0 +1,46 @@
+plugins {
+    id  'org.starchartlabs.flare.metadata-base'
+}
+
+projectMetaData{
+    github {
+        repository 'owner', 'repository'
+        
+        developer 'dev-usernameonly'
+        developer 'dev-username', 'dev-name'
+        developers file('developers.properties')
+        
+        contributor 'contrib-usernameonly'
+        contributor 'contrib-username', 'contrib-name'
+        contributors file('contributors.properties')
+    }
+    
+    licenses {
+        license 'license/name', 'license/tag', 'license/url', 'license/distribution'
+        apache2()
+        mit 'mit/distribution'
+        epl 'epl/distribution'
+    }
+}
+
+task metaDataPrintout {
+    doLast{
+        project.logger.lifecycle("url: ${projectMetaData.url}")
+        
+        project.logger.lifecycle("scm.vcsUrl: ${projectMetaData.scm.vcsUrl}")
+        project.logger.lifecycle("scm.connection: ${projectMetaData.scm.connection}")
+        project.logger.lifecycle("scm.developerConnection: ${projectMetaData.scm.developerConnection}")
+        
+        projectMetaData.developers.each { developer ->
+            project.logger.lifecycle("developer: ${developer.id}:${developer.name}:${developer.url}")
+        }
+        
+        projectMetaData.contributors.each { contributor ->
+            project.logger.lifecycle("contributor: ${contributor.name}:${contributor.url}")
+        }
+        
+        projectMetaData.licenses.each { license ->
+            project.logger.lifecycle("license: ${license.name}:${license.tag}:${license.url}:${license.distribution}")
+        }
+    }
+}

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/standardSetup.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/base/standardSetup.gradle
@@ -1,0 +1,50 @@
+plugins {
+    id  'org.starchartlabs.flare.metadata-base'
+}
+
+projectMetaData{
+    url = 'http://url'
+    
+    scm {
+        vcsUrl = 'http://scm/url'
+        connection = 'scm/connection'
+        developerConnection = 'scm/developerConnection'
+    }
+    
+    developers {
+        developer 'developer/id', 'developer/name', 'developer/url'
+    }
+    
+    contributors {
+        contributor 'contributor/name', 'contributor/url'
+    }
+    
+    licenses {
+        license 'license/name', 'license/tag', 'license/url', 'license/distribution'
+        apache2()
+        mit 'mit/distribution'
+        epl 'epl/distribution'
+    }
+}
+
+task metaDataPrintout {
+    doLast{
+        project.logger.lifecycle("url: ${projectMetaData.url}")
+        
+        project.logger.lifecycle("scm.vcsUrl: ${projectMetaData.scm.vcsUrl}")
+        project.logger.lifecycle("scm.connection: ${projectMetaData.scm.connection}")
+        project.logger.lifecycle("scm.developerConnection: ${projectMetaData.scm.developerConnection}")
+        
+        projectMetaData.developers.each { developer ->
+            project.logger.lifecycle("developer: ${developer.id}:${developer.name}:${developer.url}")
+        }
+        
+        projectMetaData.contributors.each { contributor ->
+            project.logger.lifecycle("contributor: ${contributor.name}:${contributor.url}")
+        }
+        
+        projectMetaData.licenses.each { license ->
+            project.logger.lifecycle("license: ${license.name}:${license.tag}:${license.url}:${license.distribution}")
+        }
+    }
+}

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/contributors.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/contributors.properties
@@ -1,0 +1,4 @@
+# Comment
+
+contrib-file-usernameonly
+contrib-file-username, contrib-file-name

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/developers.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/developers.properties
@@ -1,0 +1,4 @@
+# Comment
+
+dev-file-usernameonly
+dev-file-username, dev-file-name

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
@@ -5,6 +5,31 @@ plugins {
     id 'maven-publish'
 }
 
+projectMetaData{
+    url = 'http://url'
+    
+    scm {
+        vcsUrl = 'http://scm/url'
+        connection = 'scm/connection'
+        developerConnection = 'scm/developerConnection'
+    }
+    
+    developers {
+        developer 'developer/id', 'developer/name', 'developer/url'
+    }
+    
+    contributors {
+        contributor 'contributor/name', 'contributor/url'
+    }
+    
+    licenses {
+        license 'license/name', 'license/tag', 'license/url', 'license/distribution'
+        apache2()
+        mit 'mit/distribution'
+        epl 'epl/distribution'
+    }
+}
+
 repositories {
     jcenter()
 }
@@ -62,6 +87,29 @@ task outputMavenArtifacts {
     }
 }
 
+task metaDataPrintout {
+    doLast{
+        project.logger.lifecycle("url: ${projectMetaData.url}")
+        
+        project.logger.lifecycle("scm.vcsUrl: ${projectMetaData.scm.vcsUrl}")
+        project.logger.lifecycle("scm.connection: ${projectMetaData.scm.connection}")
+        project.logger.lifecycle("scm.developerConnection: ${projectMetaData.scm.developerConnection}")
+        
+        projectMetaData.developers.each { developer ->
+            project.logger.lifecycle("developer: ${developer.id}:${developer.name}:${developer.url}")
+        }
+        
+        projectMetaData.contributors.each { contributor ->
+            project.logger.lifecycle("contributor: ${contributor.name}:${contributor.url}")
+        }
+        
+        projectMetaData.licenses.each { license ->
+            project.logger.lifecycle("license: ${license.name}:${license.tag}:${license.url}:${license.distribution}")
+        }
+    }
+}
+
 check.dependsOn outputManagedCredentials
 check.dependsOn outputTestLogging
 check.dependsOn outputMavenArtifacts
+check.dependsOn metaDataPrintout

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
@@ -4,6 +4,16 @@ plugins {
     id 'maven-publish'
 }
 
+projectMetaData{
+    github {
+        repository 'owner', "${project.name}"
+    }
+    
+    licenses {
+        mit()
+    }
+}
+
 dependencies {
     testCompile 'org.testng:testng'
 }
@@ -49,5 +59,28 @@ task outputTestLogging {
     }
 }
 
+task metaDataPrintout {
+    doLast{
+        project.logger.lifecycle("url: ${projectMetaData.url}")
+        
+        project.logger.lifecycle("scm.vcsUrl: ${projectMetaData.scm.vcsUrl}")
+        project.logger.lifecycle("scm.connection: ${projectMetaData.scm.connection}")
+        project.logger.lifecycle("scm.developerConnection: ${projectMetaData.scm.developerConnection}")
+        
+        projectMetaData.developers.each { developer ->
+            project.logger.lifecycle("developer: ${developer.id}:${developer.name}:${developer.url}")
+        }
+        
+        projectMetaData.contributors.each { contributor ->
+            project.logger.lifecycle("contributor: ${contributor.name}:${contributor.url}")
+        }
+        
+        projectMetaData.licenses.each { license ->
+            project.logger.lifecycle("license: ${license.name}:${license.tag}:${license.url}:${license.distribution}")
+        }
+    }
+}
+
 check.dependsOn outputTestLogging
 check.dependsOn outputMavenArtifacts
+check.dependsOn metaDataPrintout


### PR DESCRIPTION
Adds a configuration plug-in that applies standard DSL to a project for
defining meta data, which can be referenced for populating common
properties in published artifacts