### PR TITLE
Add Plug-in for Application of Meta-Data to Generated POM Files

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - source-jars plug-in which provides tasks to build source and javadoc jars and adds them to the project's archives artifact configuration
 - Integrate source-jars with maven-publish plug-in as published artifacts
 - metadata-base plug-in which provides a DSL for re-usable project meta data values
+- Add metadata-base plug-in to multi-module-library plug-in setup
+- metadata-pom plug-in which applies meta data in metadata-base DSL to generated Maven POM files
 
 ## [0.1.0]
 ### Added

--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - source-jars plug-in which provides tasks to build source and javadoc jars and adds them to the project's archives artifact configuration
 - Integrate source-jars with maven-publish plug-in as published artifacts
 - metadata-base plug-in which provides a DSL for re-usable project meta data values
-- Add metadata-base plug-in to multi-module-library plug-in setup
+- Add metadata-base plug-in to multi-module-library plug-in setup for all projects
 - metadata-pom plug-in which applies meta data in metadata-base DSL to generated Maven POM files
+- Add metadata-pom plug-in to multi-module-library plug-in setup for all projects
 
 ## [0.1.0]
 ### Added

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Applying this convention has the following effects:
 - Adds DSL for configuration project meta data
 - Loads developers into project meta data from file `"${rootDir}/developers.properties"`, if it exists
 - Loads contributors into project meta data from file `"${rootDir}/contributors.properties"`, if it exists
+- Applies project meta data to generated Maven POM files
 
 Individual plug-ins used to apply these changes:
 
@@ -49,6 +50,7 @@ Individual plug-ins used to apply these changes:
 - org.starchartlabs.flare.merge-coverage-reports
 - org.starchartlabs.flare.source-jars
 - org.starchartlabs.flare.metadata-base
+- org.starchartlabs.flare.metadata-pom
 
 ## Migrating From Previous Plug-ins
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,9 +20,16 @@ eclipse {
     }
 }
 
-// JCenter is the Gradle plug-in standard
+// JCenter is the Gradle plug-in standard, fallback to maven central
 repositories { 
-    jcenter() 
+    jcenter()
+}
+
+//Force use of databind with security fixes
+configurations.all {
+    resolutionStrategy {
+        force 'com.fasterxml.jackson.core:jackson-databind:2.9.9', 'com.fasterxml.jackson.core:jackson-databind:2.9.9.2'
+    }
 }
 
 dependencies { 
@@ -30,7 +37,7 @@ dependencies {
     compile 'org.starchartlabs.alloy:alloy-core:0.4.1'
     
     testCompile gradleTestKit()
-    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.8'
+    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.9'
     testCompile 'org.mockito:mockito-core:2.25.0'
     testCompile 'org.testng:testng:6.14.3'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     compile 'org.starchartlabs.alloy:alloy-core:0.4.1'
     
     testCompile gradleTestKit()
+    testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.9.8'
     testCompile 'org.mockito:mockito-core:2.25.0'
     testCompile 'org.testng:testng:6.14.3'
 }
@@ -154,6 +155,18 @@ gradlePlugin {
             displayName = 'Merge Coverage Reports'
             description = 'Adds a task which generates a single Jacoco XML report with coverage data from all sub-modules'
             implementationClass = 'org.starchartlabs.flare.plugins.plugin.MergeCoverageReportsPlugin'
+        }
+        metadataBasePlugin {
+            id = 'org.starchartlabs.flare.metadata-base'
+            displayName = 'Meta Data Configuration'
+            description = 'Provides a configurable DSL for defining published project meta data'
+            implementationClass = 'org.starchartlabs.flare.plugins.plugin.MetaDataBasePlugin'
+        }
+        metadataPomPlugin {
+            id = 'org.starchartlabs.flare.metadata-pom'
+            displayName = 'Meta Data POM Application'
+            description = 'Applies values from a configurable DSL of published project meta data to generated Maven POM files'
+            implementationClass = 'org.starchartlabs.flare.plugins.plugin.MetaDataPomPlugin'
         }
         sourceJarsPlugin {
             id = 'org.starchartlabs.flare.source-jars'

--- a/docs/FLARE_PUBLISHING_MIGRATION.md
+++ b/docs/FLARE_PUBLISHING_MIGRATION.md
@@ -15,3 +15,7 @@ The functionality of the `pom-source-jar-artifacts` plug-in has been combined wi
 ## org.starchartlabs.flare.published-info-base
 
 The DSL of the published info plug-in has been re-designed, and is now the metadata-base plug in. See the [new plug-ins](./PLUGINS.md) documentation for details on the new DSL form. All previous `publishedInfo` values are supported
+
+## org.starchartlabs.flare.pom-published-info
+
+The DSL applied has been switched to the project meta-data DSL - otherwise, the only change necessary is to update the plug-in ID to `org.starchartlabs.flare.metadata-pom`

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -146,3 +146,7 @@ Regradless of use of the GitHub configuration DSL, meta data configuration inclu
 * Eclipse Public License 1.0 (`epl`)
 
 All licenses have a DSL which omits distribution (defaulting to `repo`), and a DSL which accepts a distribution specification. Pull requests to add additional pre-configured licenses are welcome!
+
+## org.starchartlabs.flare.metadata-pom
+
+The meta data POM plug-in takes data defined in the DSL defined by the `org.starchartlabs.flare.metadata-base` plug-in and applies it to the generated POM file for any `MavenPublication` definitions provided by the `maven-publish` plug-in

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Contributor.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Contributor.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomContributor;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -119,6 +120,14 @@ public class Contributor {
      */
     public void setUrl(@Nullable String url) {
         this.url = url;
+    }
+
+    // TODO romeara
+    public Action<MavenPomContributor> getPomConfiguration() {
+        return (pomContributor -> {
+            pomContributor.getName().set(getName());
+            pomContributor.getUrl().set(getUrl());
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Contributor.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Contributor.java
@@ -122,7 +122,10 @@ public class Contributor {
         this.url = url;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "contributor" properties
+     * @since 0.2.0
+     */
     public Action<MavenPomContributor> getPomConfiguration() {
         return (pomContributor -> {
             pomContributor.getName().set(getName());

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ContributorContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ContributorContainer.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomContributorSpec;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -136,6 +137,15 @@ public class ContributorContainer {
         contributors.add(new Contributor().configure(action));
 
         return this;
+    }
+
+    // TODO romeara
+    public Action<MavenPomContributorSpec> getPomConfiguration() {
+        return (pomContributors -> {
+            getContributors().stream()
+                    .map(Contributor::getPomConfiguration)
+                    .forEach(pomContributors::contributor);
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ContributorContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ContributorContainer.java
@@ -139,12 +139,15 @@ public class ContributorContainer {
         return this;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "contributors" properties
+     * @since 0.2.0
+     */
     public Action<MavenPomContributorSpec> getPomConfiguration() {
         return (pomContributors -> {
             getContributors().stream()
-                    .map(Contributor::getPomConfiguration)
-                    .forEach(pomContributors::contributor);
+            .map(Contributor::getPomConfiguration)
+            .forEach(pomContributors::contributor);
         });
     }
 

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Developer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Developer.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomDeveloper;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -141,6 +142,15 @@ public class Developer {
      */
     public void setUrl(@Nullable String url) {
         this.url = url;
+    }
+
+    // TODO romeara
+    public Action<MavenPomDeveloper> getPomConfiguration() {
+        return (pomDeveloper -> {
+            pomDeveloper.getId().set(getId());
+            pomDeveloper.getName().set(getName());
+            pomDeveloper.getUrl().set(getUrl());
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Developer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Developer.java
@@ -144,7 +144,10 @@ public class Developer {
         this.url = url;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "developer" properties
+     * @since 0.2.0
+     */
     public Action<MavenPomDeveloper> getPomConfiguration() {
         return (pomDeveloper -> {
             pomDeveloper.getId().set(getId());

--- a/src/main/java/org/starchartlabs/flare/plugins/model/DeveloperContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/DeveloperContainer.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomDeveloperSpec;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -138,6 +139,15 @@ public class DeveloperContainer {
         developers.add(new Developer().configure(action));
 
         return this;
+    }
+
+    // TODO romeara
+    public Action<MavenPomDeveloperSpec> getPomConfiguation() {
+        return (pomDevelopers -> {
+            getDevelopers().stream()
+                    .map(Developer::getPomConfiguration)
+                    .forEach(pomDevelopers::developer);
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/DeveloperContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/DeveloperContainer.java
@@ -141,12 +141,15 @@ public class DeveloperContainer {
         return this;
     }
 
-    // TODO romeara
-    public Action<MavenPomDeveloperSpec> getPomConfiguation() {
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "developers" properties
+     * @since 0.2.0
+     */
+    public Action<MavenPomDeveloperSpec> getPomConfiguration() {
         return (pomDevelopers -> {
             getDevelopers().stream()
-                    .map(Developer::getPomConfiguration)
-                    .forEach(pomDevelopers::developer);
+            .map(Developer::getPomConfiguration)
+            .forEach(pomDevelopers::developer);
         });
     }
 

--- a/src/main/java/org/starchartlabs/flare/plugins/model/License.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/License.java
@@ -166,7 +166,10 @@ public class License {
         this.distribution = distribution;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "license" properties
+     * @since 0.2.0
+     */
     public Action<MavenPomLicense> getPomConfiguration() {
         return (pomLicense -> {
             pomLicense.getName().set(getName());

--- a/src/main/java/org/starchartlabs/flare/plugins/model/License.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/License.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomLicense;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -163,6 +164,15 @@ public class License {
      */
     public void setDistribution(String distribution) {
         this.distribution = distribution;
+    }
+
+    // TODO romeara
+    public Action<MavenPomLicense> getPomConfiguration() {
+        return (pomLicense -> {
+            pomLicense.getName().set(getName());
+            pomLicense.getUrl().set(getUrl());
+            pomLicense.getDistribution().set(getDistribution());
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/LicenseContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/LicenseContainer.java
@@ -220,7 +220,10 @@ public class LicenseContainer {
         return this;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "licenses" properties
+     * @since 0.2.0
+     */
     public Action<MavenPomLicenseSpec> getPomConfiguration() {
         return (pomLicenses -> {
             getLicenses().stream()

--- a/src/main/java/org/starchartlabs/flare/plugins/model/LicenseContainer.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/LicenseContainer.java
@@ -13,6 +13,7 @@ import java.util.Objects;
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomLicenseSpec;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -147,7 +148,7 @@ public class LicenseContainer {
 
     /**
      * Adds the Apache 2.0 license to the licenses the project may be used under with the "repo" distribution
-     * 
+     *
      * @return This container with configuration applied
      * @since 0.2.0
      */
@@ -172,7 +173,7 @@ public class LicenseContainer {
 
     /**
      * Adds the MIT license to the licenses the project may be used under with the "repo" distribution
-     * 
+     *
      * @return This container with configuration applied
      * @since 0.2.0
      */
@@ -196,7 +197,7 @@ public class LicenseContainer {
 
     /**
      * Adds the EPL 1.0 license to the licenses the project may be used under with the "repo" distribution
-     * 
+     *
      * @return This container with configuration applied
      * @since 0.2.0
      */
@@ -217,6 +218,15 @@ public class LicenseContainer {
                 distribution));
 
         return this;
+    }
+
+    // TODO romeara
+    public Action<MavenPomLicenseSpec> getPomConfiguration() {
+        return (pomLicenses -> {
+            getLicenses().stream()
+            .map(License::getPomConfiguration)
+            .forEach(pomLicenses::license);
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ProjectMetaData.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ProjectMetaData.java
@@ -8,10 +8,12 @@ package org.starchartlabs.flare.plugins.model;
 
 import java.util.Collection;
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPom;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -320,6 +322,22 @@ public class ProjectMetaData {
         licenses.configure(action);
 
         return this;
+    }
+
+    // TODO romeara
+    public Action<MavenPom> getPomConfiguration() {
+        return (pom -> {
+            Optional.ofNullable(getUrl())
+                    .ifPresent(url -> pom.getUrl().set(url));
+
+            pom.scm(scm.getPomConfiguration());
+
+            pom.developers(developers.getPomConfiguation());
+
+            pom.contributors(contributors.getPomConfiguration());
+
+            pom.licenses(licenses.getPomConfiguration());
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/ProjectMetaData.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/ProjectMetaData.java
@@ -324,15 +324,18 @@ public class ProjectMetaData {
         return this;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's properties
+     * @since 0.2.0
+     */
     public Action<MavenPom> getPomConfiguration() {
         return (pom -> {
             Optional.ofNullable(getUrl())
-                    .ifPresent(url -> pom.getUrl().set(url));
+            .ifPresent(url -> pom.getUrl().set(url));
 
             pom.scm(scm.getPomConfiguration());
 
-            pom.developers(developers.getPomConfiguation());
+            pom.developers(developers.getPomConfiguration());
 
             pom.contributors(contributors.getPomConfiguration());
 

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Scm.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Scm.java
@@ -7,10 +7,12 @@
 package org.starchartlabs.flare.plugins.model;
 
 import java.util.Objects;
+import java.util.Optional;
 
 import javax.annotation.Nullable;
 
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomScm;
 import org.starchartlabs.alloy.core.MoreObjects;
 
 import groovy.lang.Closure;
@@ -141,6 +143,20 @@ public class Scm {
      */
     public void setDeveloperConnection(@Nullable String developerConnection) {
         this.developerConnection = developerConnection;
+    }
+
+    // TODO romeara
+    public Action<MavenPomScm> getPomConfiguration() {
+        return (pomScm -> {
+            Optional.ofNullable(getVcsUrl())
+                    .ifPresent(url -> pomScm.getUrl().set(url));
+
+            Optional.ofNullable(getConnection())
+                    .ifPresent(connection -> pomScm.getConnection().set(connection));
+
+            Optional.ofNullable(getDeveloperConnection())
+                    .ifPresent(developerConnection -> pomScm.getDeveloperConnection().set(developerConnection));
+        });
     }
 
     @Override

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Scm.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Scm.java
@@ -145,17 +145,20 @@ public class Scm {
         this.developerConnection = developerConnection;
     }
 
-    // TODO romeara
+    /**
+     * @return An action which configures meta-data values on a generated Maven POM's "scm" properties
+     * @since 0.2.0
+     */
     public Action<MavenPomScm> getPomConfiguration() {
         return (pomScm -> {
             Optional.ofNullable(getVcsUrl())
-                    .ifPresent(url -> pomScm.getUrl().set(url));
+            .ifPresent(url -> pomScm.getUrl().set(url));
 
             Optional.ofNullable(getConnection())
-                    .ifPresent(connection -> pomScm.getConnection().set(connection));
+            .ifPresent(connection -> pomScm.getConnection().set(connection));
 
             Optional.ofNullable(getDeveloperConnection())
-                    .ifPresent(developerConnection -> pomScm.getDeveloperConnection().set(developerConnection));
+            .ifPresent(developerConnection -> pomScm.getDeveloperConnection().set(developerConnection));
         });
     }
 

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataPomPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataPomPlugin.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.plugin;
+
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.publish.PublishingExtension;
+import org.gradle.api.publish.maven.MavenPublication;
+import org.starchartlabs.flare.plugins.model.ProjectMetaData;
+
+//TODO romeara multi-module plug-in application, multi-module markdown doc
+/**
+ * Convention plug-in that takes structures for defining project meta data from the meta-data base plug-in and applies
+ * them to any POMs generated in relation to MavenPublication instances provided by the maven-publish plug-in
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class MetaDataPomPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply("org.starchartlabs.flare.metadata-base");
+
+        ProjectMetaData projectMetaData = project.getExtensions().getByType(ProjectMetaData.class);
+
+        // Another option was applying configuration to the GenerateMavenPom tasks in a doFirst block, but that removes
+        // any ability to accurately output or alter the POM fields after this configuration is applied
+
+        // After evaluate to all setting values in meta-data before applying them
+        project.afterEvaluate(p -> {
+            project.getPluginManager().withPlugin("maven-publish", mavenPublishPlugin -> {
+                PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
+
+                publishing.getPublications().withType(MavenPublication.class).all(publication -> {
+                    publication.pom(projectMetaData.getPomConfiguration());
+                });
+            });
+        });
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataPomPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataPomPlugin.java
@@ -12,7 +12,6 @@ import org.gradle.api.publish.PublishingExtension;
 import org.gradle.api.publish.maven.MavenPublication;
 import org.starchartlabs.flare.plugins.model.ProjectMetaData;
 
-//TODO romeara multi-module plug-in application, multi-module markdown doc
 /**
  * Convention plug-in that takes structures for defining project meta data from the meta-data base plug-in and applies
  * them to any POMs generated in relation to MavenPublication instances provided by the maven-publish plug-in

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
@@ -34,6 +34,7 @@ public class MultiModuleLibraryPlugin implements Plugin<Project> {
             p.getPluginManager().apply("org.starchartlabs.flare.increased-test-logging");
             p.getPluginManager().apply("org.starchartlabs.flare.source-jars");
             p.getPluginManager().apply("org.starchartlabs.flare.metadata-base");
+            p.getPluginManager().apply("org.starchartlabs.flare.metadata-pom");
 
             DependencyConstraints dependencyConstraints = p.getExtensions().getByType(DependencyConstraints.class);
             ProjectMetaData projectMetaData = p.getExtensions().getByType(ProjectMetaData.class);

--- a/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.metadata-pom.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.metadata-pom.properties
@@ -1,0 +1,1 @@
+implementation-class=org.starchartlabs.flare.plugins.plugin.MetaDataPomPlugin

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorContrainerTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorContrainerTest.java
@@ -6,7 +6,12 @@
  */
 package org.starchartlabs.flare.plugins.test.model;
 
+import java.util.Collections;
+
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomContributor;
+import org.gradle.api.publish.maven.MavenPomContributorSpec;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.Contributor;
 import org.starchartlabs.flare.plugins.model.ContributorContainer;
 import org.testng.Assert;
@@ -80,6 +85,29 @@ public class ContributorContrainerTest {
 
         Assert.assertEquals(result.getContributors().size(), 1);
         Assert.assertEquals(result.getContributors().iterator().next(), new Contributor("name", "url"));
+    }
+
+    @Test
+    public void getPomConfiguration() throws Exception {
+        Action<MavenPomContributor> action = (a -> {
+        });
+        Contributor contributor = Mockito.mock(Contributor.class);
+        Mockito.when(contributor.getPomConfiguration()).thenReturn(action);
+
+        MavenPomContributorSpec pomContributors = Mockito.mock(MavenPomContributorSpec.class);
+
+        ContributorContainer developerContainer = new ContributorContainer();
+        developerContainer.setContributors(Collections.singletonList(contributor));
+
+        try {
+            developerContainer.getPomConfiguration().execute(pomContributors);
+        } finally {
+            Mockito.verify(contributor).getPomConfiguration();
+            Mockito.verify(pomContributors).contributor(action);
+
+            Mockito.verifyNoMoreInteractions(pomContributors,
+                    contributor);
+        }
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ContributorTest.java
@@ -7,6 +7,9 @@
 package org.starchartlabs.flare.plugins.test.model;
 
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.maven.MavenPomContributor;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.Contributor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -56,6 +59,33 @@ public class ContributorTest {
 
         Assert.assertEquals(result.getName(), "name");
         Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getPomConfiguration() throws Exception {
+        Property<String> nameProperty = Mockito.mock(Property.class);
+        Property<String> urlProperty = Mockito.mock(Property.class);
+
+        MavenPomContributor pomContributor = Mockito.mock(MavenPomContributor.class);
+        Mockito.when(pomContributor.getName()).thenReturn(nameProperty);
+        Mockito.when(pomContributor.getUrl()).thenReturn(urlProperty);
+
+        Contributor contributor = new Contributor("name", "url");
+
+        try {
+            Action<MavenPomContributor> pomConfiguration = contributor.getPomConfiguration();
+
+            Assert.assertNotNull(pomConfiguration);
+
+            pomConfiguration.execute(pomContributor);
+        } finally {
+            Mockito.verify(pomContributor).getName();
+            Mockito.verify(pomContributor).getUrl();
+
+            Mockito.verify(nameProperty).set(contributor.getName());
+            Mockito.verify(urlProperty).set(contributor.getUrl());
+        }
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperContainerTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperContainerTest.java
@@ -6,7 +6,12 @@
  */
 package org.starchartlabs.flare.plugins.test.model;
 
+import java.util.Collections;
+
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomDeveloper;
+import org.gradle.api.publish.maven.MavenPomDeveloperSpec;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.Developer;
 import org.starchartlabs.flare.plugins.model.DeveloperContainer;
 import org.testng.Assert;
@@ -81,6 +86,29 @@ public class DeveloperContainerTest {
 
         Assert.assertEquals(result.getDevelopers().size(), 1);
         Assert.assertEquals(result.getDevelopers().iterator().next(), new Developer("id", "name", "url"));
+    }
+
+    @Test
+    public void getPomConfiguration() throws Exception {
+        Action<MavenPomDeveloper> action = (a -> {
+        });
+        Developer developer = Mockito.mock(Developer.class);
+        Mockito.when(developer.getPomConfiguration()).thenReturn(action);
+
+        MavenPomDeveloperSpec pomDevelopers = Mockito.mock(MavenPomDeveloperSpec.class);
+
+        DeveloperContainer developerContainer = new DeveloperContainer();
+        developerContainer.setDevelopers(Collections.singletonList(developer));
+
+        try {
+            developerContainer.getPomConfiguration().execute(pomDevelopers);
+        } finally {
+            Mockito.verify(developer).getPomConfiguration();
+            Mockito.verify(pomDevelopers).developer(action);
+
+            Mockito.verifyNoMoreInteractions(pomDevelopers,
+                    developer);
+        }
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/DeveloperTest.java
@@ -7,6 +7,9 @@
 package org.starchartlabs.flare.plugins.test.model;
 
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.maven.MavenPomDeveloper;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.Developer;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -66,6 +69,37 @@ public class DeveloperTest {
         Assert.assertEquals(result.getId(), "id");
         Assert.assertEquals(result.getName(), "name");
         Assert.assertEquals(result.getUrl(), "url");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getPomConfiguration() throws Exception {
+        Property<String> idProperty = Mockito.mock(Property.class);
+        Property<String> nameProperty = Mockito.mock(Property.class);
+        Property<String> urlProperty = Mockito.mock(Property.class);
+
+        MavenPomDeveloper pomDeveloper = Mockito.mock(MavenPomDeveloper.class);
+        Mockito.when(pomDeveloper.getId()).thenReturn(idProperty);
+        Mockito.when(pomDeveloper.getName()).thenReturn(nameProperty);
+        Mockito.when(pomDeveloper.getUrl()).thenReturn(urlProperty);
+
+        Developer developer = new Developer("id", "name", "url");
+
+        try {
+            Action<MavenPomDeveloper> pomConfiguration = developer.getPomConfiguration();
+
+            Assert.assertNotNull(pomConfiguration);
+
+            pomConfiguration.execute(pomDeveloper);
+        } finally {
+            Mockito.verify(pomDeveloper).getId();
+            Mockito.verify(pomDeveloper).getName();
+            Mockito.verify(pomDeveloper).getUrl();
+
+            Mockito.verify(idProperty).set(developer.getId());
+            Mockito.verify(nameProperty).set(developer.getName());
+            Mockito.verify(urlProperty).set(developer.getUrl());
+        }
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseContainerTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseContainerTest.java
@@ -6,7 +6,12 @@
  */
 package org.starchartlabs.flare.plugins.test.model;
 
+import java.util.Collections;
+
 import org.gradle.api.Action;
+import org.gradle.api.publish.maven.MavenPomLicense;
+import org.gradle.api.publish.maven.MavenPomLicenseSpec;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.License;
 import org.starchartlabs.flare.plugins.model.LicenseContainer;
 import org.testng.Assert;
@@ -150,6 +155,29 @@ public class LicenseContainerTest {
         Assert.assertEquals(result.getLicenses().iterator().next(),
                 new License("Eclipse Public License 1.0", "EPL", "https://opensource.org/licenses/EPL-1.0",
                         "distribution"));
+    }
+
+    @Test
+    public void getPomConfiguration() throws Exception {
+        Action<MavenPomLicense> action = (a -> {
+        });
+        License license = Mockito.mock(License.class);
+        Mockito.when(license.getPomConfiguration()).thenReturn(action);
+
+        MavenPomLicenseSpec pomLicenses = Mockito.mock(MavenPomLicenseSpec.class);
+
+        LicenseContainer licenseContainer = new LicenseContainer();
+        licenseContainer.setLicenses(Collections.singletonList(license));
+
+        try {
+            licenseContainer.getPomConfiguration().execute(pomLicenses);
+        } finally {
+            Mockito.verify(license).getPomConfiguration();
+            Mockito.verify(pomLicenses).license(action);
+
+            Mockito.verifyNoMoreInteractions(pomLicenses,
+                    license);
+        }
     }
 
     private static class TestClosure extends Closure<LicenseContainer> {

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/LicenseTest.java
@@ -7,6 +7,9 @@
 package org.starchartlabs.flare.plugins.test.model;
 
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.maven.MavenPomLicense;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.License;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -76,6 +79,37 @@ public class LicenseTest {
         Assert.assertEquals(result.getTag(), "tag");
         Assert.assertEquals(result.getUrl(), "url");
         Assert.assertEquals(result.getDistribution(), "distribution");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getPomConfiguration() throws Exception {
+        Property<String> nameProperty = Mockito.mock(Property.class);
+        Property<String> urlProperty = Mockito.mock(Property.class);
+        Property<String> distributionProperty = Mockito.mock(Property.class);
+
+        MavenPomLicense pomLicense = Mockito.mock(MavenPomLicense.class);
+        Mockito.when(pomLicense.getName()).thenReturn(nameProperty);
+        Mockito.when(pomLicense.getUrl()).thenReturn(urlProperty);
+        Mockito.when(pomLicense.getDistribution()).thenReturn(distributionProperty);
+
+        License license = new License("name", "tag", "url", "distribution");
+
+        try {
+            Action<MavenPomLicense> pomConfiguration = license.getPomConfiguration();
+
+            Assert.assertNotNull(pomConfiguration);
+
+            pomConfiguration.execute(pomLicense);
+        } finally {
+            Mockito.verify(pomLicense).getName();
+            Mockito.verify(pomLicense).getUrl();
+            Mockito.verify(pomLicense).getDistribution();
+
+            Mockito.verify(nameProperty).set(license.getName());
+            Mockito.verify(urlProperty).set(license.getUrl());
+            Mockito.verify(distributionProperty).set(license.getDistribution());
+        }
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ProjectMetaDataTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ProjectMetaDataTest.java
@@ -7,6 +7,13 @@
 package org.starchartlabs.flare.plugins.test.model;
 
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.maven.MavenPom;
+import org.gradle.api.publish.maven.MavenPomContributorSpec;
+import org.gradle.api.publish.maven.MavenPomDeveloperSpec;
+import org.gradle.api.publish.maven.MavenPomLicenseSpec;
+import org.gradle.api.publish.maven.MavenPomScm;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.Contributor;
 import org.starchartlabs.flare.plugins.model.ContributorContainer;
 import org.starchartlabs.flare.plugins.model.Developer;
@@ -171,6 +178,64 @@ public class ProjectMetaDataTest {
 
         Assert.assertEquals(result.getLicenses().size(), 1);
         Assert.assertEquals(result.getLicenses().iterator().next(), new License("name", "tag", "url", "distribution"));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getPomConfiguration() throws Exception {
+        Action<MavenPomScm> scmAction = (a -> {
+        });
+        Action<MavenPomDeveloperSpec> developersAction = (a -> {
+        });
+        Action<MavenPomContributorSpec> contributorsAction = (a -> {
+        });
+        Action<MavenPomLicenseSpec> licensesAction = (a -> {
+        });
+
+        Scm scm = Mockito.mock(Scm.class);
+        DeveloperContainer developers = Mockito.mock(DeveloperContainer.class);
+        ContributorContainer contributors = Mockito.mock(ContributorContainer.class);
+        LicenseContainer licenses = Mockito.mock(LicenseContainer.class);
+
+        Mockito.when(scm.getPomConfiguration()).thenReturn(scmAction);
+        Mockito.when(developers.getPomConfiguration()).thenReturn(developersAction);
+        Mockito.when(contributors.getPomConfiguration()).thenReturn(contributorsAction);
+        Mockito.when(licenses.getPomConfiguration()).thenReturn(licensesAction);
+
+        Property<String> urlProperty = Mockito.mock(Property.class);
+
+        MavenPom pom = Mockito.mock(MavenPom.class);
+        Mockito.when(pom.getUrl()).thenReturn(urlProperty);
+
+        ProjectMetaData projectMetaData = new ProjectMetaData("url", scm, developers, contributors, licenses);
+
+        try {
+            projectMetaData.getPomConfiguration().execute(pom);
+        } finally {
+            Mockito.verify(pom).getUrl();
+            Mockito.verify(urlProperty).set(projectMetaData.getUrl());
+
+            Mockito.verify(scm).getPomConfiguration();
+            Mockito.verify(pom).scm(scmAction);
+
+            Mockito.verify(developers).getPomConfiguration();
+            Mockito.verify(pom).developers(developersAction);
+
+            Mockito.verify(contributors).getPomConfiguration();
+            Mockito.verify(pom).contributors(contributorsAction);
+
+            Mockito.verify(licenses).getPomConfiguration();
+            Mockito.verify(pom).licenses(licensesAction);
+
+            Mockito.verifyNoMoreInteractions(
+                    pom,
+                    urlProperty,
+                    scm,
+                    developers,
+                    contributors,
+                    licenses);
+        }
+
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ScmTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ScmTest.java
@@ -7,6 +7,9 @@
 package org.starchartlabs.flare.plugins.test.model;
 
 import org.gradle.api.Action;
+import org.gradle.api.provider.Property;
+import org.gradle.api.publish.maven.MavenPomScm;
+import org.mockito.Mockito;
 import org.starchartlabs.flare.plugins.model.Scm;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -66,6 +69,42 @@ public class ScmTest {
         Assert.assertEquals(result.getVcsUrl(), "vcsUrl");
         Assert.assertEquals(result.getConnection(), "connection");
         Assert.assertEquals(result.getDeveloperConnection(), "developerConnection");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void getPomConfiguration() throws Exception {
+        Property<String> urlProperty = Mockito.mock(Property.class);
+        Property<String> connectionProperty = Mockito.mock(Property.class);
+        Property<String> developerConnectionProperty = Mockito.mock(Property.class);
+
+        MavenPomScm pomScm = Mockito.mock(MavenPomScm.class);
+        Mockito.when(pomScm.getUrl()).thenReturn(urlProperty);
+        Mockito.when(pomScm.getConnection()).thenReturn(connectionProperty);
+        Mockito.when(pomScm.getDeveloperConnection()).thenReturn(developerConnectionProperty);
+
+        Scm scm = new Scm("vcsUrl", "connection", "developerConnection");
+
+        try {
+            Action<MavenPomScm> pomConfiguration = scm.getPomConfiguration();
+
+            Assert.assertNotNull(pomConfiguration);
+
+            pomConfiguration.execute(pomScm);
+        } finally {
+            Mockito.verify(pomScm).getUrl();
+            Mockito.verify(pomScm).getConnection();
+            Mockito.verify(pomScm).getDeveloperConnection();
+
+            Mockito.verify(urlProperty).set(scm.getVcsUrl());
+            Mockito.verify(connectionProperty).set(scm.getConnection());
+            Mockito.verify(developerConnectionProperty).set(scm.getDeveloperConnection());
+
+            Mockito.verifyNoMoreInteractions(pomScm,
+                    urlProperty,
+                    connectionProperty,
+                    developerConnectionProperty);
+        }
     }
 
     @Test

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataPomPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataPomPluginIntegrationTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.starchartlabs.flare.plugins.test.TestGradleProject;
+import org.starchartlabs.flare.plugins.test.pom.PomContributor;
+import org.starchartlabs.flare.plugins.test.pom.PomDeveloper;
+import org.starchartlabs.flare.plugins.test.pom.PomLicense;
+import org.starchartlabs.flare.plugins.test.pom.PomProject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+
+@Listeners(value = { IntegrationTestListener.class })
+public class MetaDataPomPluginIntegrationTest {
+
+    private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
+            "metadata", "pom");
+
+    private static final Path STANDARD_SETUP_FILE = BUILD_FILE_DIRECTORY.resolve("build.gradle");
+
+    private Path standardSetupProjectPath;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        standardSetupProjectPath = TestGradleProject.builder(STANDARD_SETUP_FILE)
+                .build()
+                .getProjectDirectory();
+    }
+
+    @Test
+    public void standardSetup() throws Exception {
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(standardSetupProjectPath.toFile())
+                .withArguments("generatePomFileForMavenPublication", "--stacktrace")
+                .withGradleVersion("5.0")
+                .build();
+
+        TaskOutcome outcome = result.task(":generatePomFileForMavenPublication").getOutcome();
+        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
+
+        // POM validation
+        validatePom(standardSetupProjectPath, "maven");
+    }
+
+    private void validatePom(Path projectDirectory, String publication) throws Exception {
+        Path generatedPom = projectDirectory.resolve("build").resolve("publications").resolve(publication)
+                .resolve("pom-default.xml");
+        XmlMapper xmlMapper = new XmlMapper();
+        PomProject value = xmlMapper.readValue(generatedPom.toFile(), PomProject.class);
+
+        Assert.assertEquals(value.getUrl(), "http://url");
+
+        Assert.assertEquals(value.getScm().getUrl(), "http://scm/url");
+        Assert.assertEquals(value.getScm().getConnection(), "scm/connection");
+        Assert.assertEquals(value.getScm().getDeveloperConnection(), "scm/developerConnection");
+
+        Assert.assertEquals(value.getDevelopers().size(), 1);
+        PomDeveloper developer = value.getDevelopers().iterator().next();
+
+        Assert.assertEquals(developer.getId(), "developer/id");
+        Assert.assertEquals(developer.getName(), "developer/name");
+        Assert.assertEquals(developer.getUrl(), "developer/url");
+
+        Assert.assertEquals(value.getContributors().size(), 1);
+        PomContributor contributor = value.getContributors().iterator().next();
+
+        Assert.assertEquals(contributor.getName(), "contributor/name");
+        Assert.assertEquals(contributor.getUrl(), "contributor/url");
+
+        Assert.assertEquals(value.getLicenses().size(), 1);
+        PomLicense license = value.getLicenses().iterator().next();
+
+        Assert.assertEquals(license.getName(), "license/name");
+        Assert.assertEquals(license.getUrl(), "license/url");
+        Assert.assertEquals(license.getDistribution(), "license/distribution");
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomContributor.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomContributor.java
@@ -18,6 +18,15 @@ public class PomContributor {
 
     private String url;
 
+    public PomContributor() {
+
+    }
+
+    public PomContributor(String name, String url) {
+        this.name = name;
+        this.url = url;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomContributor.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomContributor.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.pom;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+public class PomContributor {
+
+    private String name;
+
+    private String url;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(),
+                getUrl());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PomContributor) {
+            PomContributor compare = (PomContributor) obj;
+
+            result = Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getUrl(), getUrl());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("name", getName())
+                .add("url", getUrl())
+                .toString();
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomDeveloper.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomDeveloper.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.pom;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+public class PomDeveloper {
+
+    private String id;
+
+    private String name;
+
+    private String url;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId(),
+                getName(),
+                getUrl());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PomDeveloper) {
+            PomDeveloper compare = (PomDeveloper) obj;
+
+            result = Objects.equals(compare.getId(), getId())
+                    && Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getUrl(), getUrl());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("id", getId())
+                .add("name", getName())
+                .add("url", getUrl())
+                .toString();
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomDeveloper.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomDeveloper.java
@@ -20,6 +20,16 @@ public class PomDeveloper {
 
     private String url;
 
+    public PomDeveloper() {
+
+    }
+
+    public PomDeveloper(String id, String name, String url) {
+        this.id = id;
+        this.name = name;
+        this.url = url;
+    }
+
     public String getId() {
         return id;
     }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomLicense.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomLicense.java
@@ -20,6 +20,16 @@ public class PomLicense {
 
     private String distribution;
 
+    public PomLicense() {
+
+    }
+
+    public PomLicense(String name, String url, String distribution) {
+        this.name = name;
+        this.url = url;
+        this.distribution = distribution;
+    }
+
     public String getName() {
         return name;
     }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomLicense.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomLicense.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.pom;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+public class PomLicense {
+
+    private String name;
+
+    private String url;
+
+    private String distribution;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getDistribution() {
+        return distribution;
+    }
+
+    public void setDistribution(String distribution) {
+        this.distribution = distribution;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getName(),
+                getUrl(),
+                getDistribution());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PomLicense) {
+            PomLicense compare = (PomLicense) obj;
+
+            result = Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getUrl(), getUrl())
+                    && Objects.equals(compare.getDistribution(), getDistribution());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("name", getName())
+                .add("url", getUrl())
+                .add("distribution", getDistribution())
+                .toString();
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomProject.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomProject.java
@@ -28,6 +28,19 @@ public class PomProject {
 
     private List<PomLicense> licenses;
 
+    public PomProject() {
+
+    }
+
+    public PomProject(String url, PomScm scm, List<PomDeveloper> developers, List<PomContributor> contributors,
+            List<PomLicense> licenses) {
+        this.url = url;
+        this.scm = scm;
+        this.developers = developers;
+        this.contributors = contributors;
+        this.licenses = licenses;
+    }
+
     public String getUrl() {
         return url;
     }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomProject.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomProject.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.pom;
+
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class PomProject {
+
+    private String url;
+
+    private PomScm scm;
+
+    private List<PomDeveloper> developers;
+
+    private List<PomContributor> contributors;
+
+    private List<PomLicense> licenses;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public PomScm getScm() {
+        return scm;
+    }
+
+    public void setScm(PomScm scm) {
+        this.scm = scm;
+    }
+
+    public List<PomDeveloper> getDevelopers() {
+        return developers;
+    }
+
+    public void setDevelopers(List<PomDeveloper> developers) {
+        this.developers = developers;
+    }
+
+    public List<PomContributor> getContributors() {
+        return contributors;
+    }
+
+    public void setContributors(List<PomContributor> contributors) {
+        this.contributors = contributors;
+    }
+
+    public List<PomLicense> getLicenses() {
+        return licenses;
+    }
+
+    public void setLicenses(List<PomLicense> licenses) {
+        this.licenses = licenses;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUrl(),
+                getScm(),
+                getDevelopers(),
+                getContributors(),
+                getLicenses());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PomProject) {
+            PomProject compare = (PomProject) obj;
+
+            result = Objects.equals(compare.getUrl(), getUrl())
+                    && Objects.equals(compare.getScm(), getScm())
+                    && Objects.equals(compare.getDevelopers(), getDevelopers())
+                    && Objects.equals(compare.getContributors(), getContributors())
+                    && Objects.equals(compare.getLicenses(), getLicenses());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("url", getUrl())
+                .add("scm", getScm())
+                .add("developers", getDevelopers())
+                .add("contributors", getContributors())
+                .add("licenses", getLicenses())
+                .toString();
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomScm.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomScm.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.pom;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+
+public class PomScm {
+
+    private String url;
+
+    private String connection;
+
+    private String developerConnection;
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getConnection() {
+        return connection;
+    }
+
+    public void setConnection(String connection) {
+        this.connection = connection;
+    }
+
+    public String getDeveloperConnection() {
+        return developerConnection;
+    }
+
+    public void setDeveloperConnection(String developerConnection) {
+        this.developerConnection = developerConnection;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getUrl(),
+                getConnection(),
+                getDeveloperConnection());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof PomScm) {
+            PomScm compare = (PomScm) obj;
+
+            result = Objects.equals(compare.getUrl(), getUrl())
+                    && Objects.equals(compare.getConnection(), getConnection())
+                    && Objects.equals(compare.getDeveloperConnection(), getDeveloperConnection());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("url", getUrl())
+                .add("connection", getConnection())
+                .add("developerConnection", getDeveloperConnection())
+                .toString();
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomScm.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomScm.java
@@ -20,6 +20,16 @@ public class PomScm {
 
     private String developerConnection;
 
+    public PomScm() {
+
+    }
+
+    public PomScm(String url, String connection, String developerConnection) {
+        this.url = url;
+        this.connection = connection;
+        this.developerConnection = developerConnection;
+    }
+
     public String getUrl() {
         return url;
     }

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/pom/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/pom/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id  'org.starchartlabs.flare.metadata-pom'
+    id 'java'
+    id 'maven-publish'
+}
+
+projectMetaData{
+    url = 'http://url'
+    
+    scm {
+        vcsUrl = 'http://scm/url'
+        connection = 'scm/connection'
+        developerConnection = 'scm/developerConnection'
+    }
+    
+    developers {
+        developer 'developer/id', 'developer/name', 'developer/url'
+    }
+    
+    contributors {
+        contributor 'contributor/name', 'contributor/url'
+    }
+    
+    licenses {
+        license 'license/name', 'license/tag', 'license/url', 'license/distribution'
+    }
+}
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            from components.java
+        }
+    }
+}
+
+//Task to run for tests: generatePomFileForMavenPublication

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
@@ -113,3 +113,4 @@ check.dependsOn outputManagedCredentials
 check.dependsOn outputTestLogging
 check.dependsOn outputMavenArtifacts
 check.dependsOn metaDataPrintout
+check.dependsOn generatePomFileForMavenPublication

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
@@ -84,3 +84,4 @@ task metaDataPrintout {
 check.dependsOn outputTestLogging
 check.dependsOn outputMavenArtifacts
 check.dependsOn metaDataPrintout
+check.dependsOn generatePomFileForMavenPublication


### PR DESCRIPTION
Cliff notes of what this does - if a user sets up the `projectMetaData` DSL, it applies the configured values to any generated Maven POM files.

This PR also adds this plug-in to the set configured in the multi-module-library plug-in