### PR TITLE
Apply constraints to configurations only for dependencies used

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - metadata-pom plug-in which applies meta data in metadata-base DSL to generated Maven POM files
 - Add metadata-pom plug-in to multi-module-library plug-in setup for all projects
 
+### Changed
+- Application of dependency-constraints is now done during the pre-resolve step for each configuration, and only constraints used by dependencies of that configuration are applied
+
 ## [0.1.0]
 ### Added
 - managed-credentials plug-in which provides a DSL for re-usable loaded credentials from multiple sources

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
@@ -128,10 +128,25 @@ public class MultiModuleLibraryPluginIntegrationTest {
 
     @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
     public void singleProjectDependencyConstraints() throws Exception {
-        String expectedLine = "Applied configuration ':compile' dependency constraint: org.testng:testng:6.14.3";
+        // Constraints should only be applied to configurations which use them
+        List<String> expectedLines = new ArrayList<>();
+        List<String> unexpectedLines = new ArrayList<>();
 
-        Assert.assertTrue(singleProjectBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
+        expectedLines.add("Applied configuration ':testCompile' dependency constraint: org.testng:testng:6.14.3");
+
+        unexpectedLines.add("Applied configuration ':compile' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':runtime' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':testRuntime' dependency constraint: org.testng:testng:6.14.3");
+
+        for (String expectedLine : expectedLines) {
+            Assert.assertTrue(singleProjectBuildResult.getOutput().contains(expectedLine),
+                    Strings.format("Did not find expected line '%s'", expectedLine));
+        }
+
+        for (String unexpectedLine : unexpectedLines) {
+            Assert.assertFalse(singleProjectBuildResult.getOutput().contains(unexpectedLine),
+                    Strings.format("Found unexpected line '%s'", unexpectedLine));
+        }
     }
 
     @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
@@ -257,14 +272,28 @@ public class MultiModuleLibraryPluginIntegrationTest {
 
     @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })
     public void multiModuleProjectDependencyContraints() throws Exception {
+        // Constraints should only be applied to configurations which use them
         List<String> expectedLines = new ArrayList<>();
+        List<String> unexpectedLines = new ArrayList<>();
 
-        expectedLines.add("Applied configuration ':one:compile' dependency constraint: org.testng:testng:6.14.3");
-        expectedLines.add("Applied configuration ':two:compile' dependency constraint: org.testng:testng:6.14.3");
+        expectedLines.add("Applied configuration ':one:testCompile' dependency constraint: org.testng:testng:6.14.3");
+        expectedLines.add("Applied configuration ':two:testCompile' dependency constraint: org.testng:testng:6.14.3");
+
+        unexpectedLines.add("Applied configuration ':one:compile' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':two:compile' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':one:runtime' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':two:runtime' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':one:testRuntime' dependency constraint: org.testng:testng:6.14.3");
+        unexpectedLines.add("Applied configuration ':two:testRuntime' dependency constraint: org.testng:testng:6.14.3");
 
         for (String expectedLine : expectedLines) {
             Assert.assertTrue(multiModuleProjectBuildResult.getOutput().contains(expectedLine),
                     Strings.format("Did not find expected line '%s'", expectedLine));
+        }
+
+        for (String unexpectedLine : unexpectedLines) {
+            Assert.assertFalse(multiModuleProjectBuildResult.getOutput().contains(unexpectedLine),
+                    Strings.format("Found unexpected line '%s'", unexpectedLine));
         }
     }
 

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/build.gradle
@@ -10,3 +10,22 @@ dependencyConstraints {
 configurations {
     createdAfterDsl
 }
+
+repositories{
+    mavenCentral()
+}
+
+dependencies {
+    compile 'org.testng:testng'
+    compile 'org.mockito:mockito-core'
+    
+    createdAfterDsl 'org.mockito:mockito-core'
+}
+
+task forceConfigurationResolution {
+    dependsOn assemble
+    
+    doFirst {
+        project.logger.info("files: ${configurations.createdAfterDsl.files}")
+    }
+}

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/dependencies.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/dependency/constraints/dependencies.properties
@@ -1,4 +1,8 @@
-group:artifact:1.0
+org.testng:testng:6.14.3
 
 # Another locked version
 group2:artifact2:2.0
+org.mockito:mockito-core:2.25.0
+
+# Not Applied anywhere
+org.starchartlabs.alloy:alloy-core:0.4.1


### PR DESCRIPTION
Change the way dependency constraints are applied so that only
constraints used for dependencies within a given configuration are
applied to that configuration. To allow this, constraint application was
moved to a "pre-resolve" step for configurations (which means
constraints are alow not applied for a configuration unless it is
actually used)

This change in behavior results in the same constraints being applied,
but prevents extraneous constraints on configurations, which could
"leak" into built artifacts in cases such as generated Maven POM files
(in POMs, this manifested as unused "dependencyManagement" entries)