### PR TITLE
Allow control over configurations constraints are applied to

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - metadata-pom plug-in which applies meta data in metadata-base DSL to generated Maven POM files
 - Add metadata-pom plug-in to multi-module-library plug-in setup for all projects
 
+### Changed
+- Started allowing limitation of the configurations dependency constraints are applied to via the constraint file specification
+
 ## [0.1.0]
 ### Added
 - managed-credentials plug-in which provides a DSL for re-usable loaded credentials from multiple sources

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Applying this convention has the following effects:
 
 - Applies a task to the root project which will create a merged Jacoco XML report in `${rootProject.buildDir}/reports/jacoco/report.xml`
 - Reads dependency versions from file `"${rootDir}/dependencies.properties"` and applies these as dependency constraints
-  - This file may have empty lines, lines starting with `#` which act as comments, or lines of the form `group:artifact:version`
+  - This file may have empty lines, lines starting with `#` which act as comments, or lines of the form `group:artifact:version[,configurations,...]`
 - Add a reference to credentials read from environment variables `BINTRAY_USER` and `BINTRAY_API_KEY`. These variables must be defined if the credentials are used
   - These credentials can be referenced by `${credentials.bintray.username}` and `${credentials.bintray.password}'
 - Increases the logging level of test events in sub-modules

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -18,7 +18,7 @@ dependencyConstraints {
 
 ### File Format
 
-The file(s) currently supported by the plug-in follow a simple format. Lines may be empty, a comment, or a version definition. Comment lines start with the `#` character. Version lines are a GAV in the format `group:artifact:version`
+The file(s) currently supported by the plug-in follow a simple format. Lines may be empty, a comment, or a version definition. Comment lines start with the `#` character. Version lines are a GAV in the format `group:artifact:version`, and may optionally include the configurations the constraint should be limited to as comma-separated values (`group:artifact:version,config1,config2,...`)
 
 ## org.starchartlabs.flare.increased-test-logging
 

--- a/src/main/java/org/starchartlabs/flare/plugins/model/Constraint.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/model/Constraint.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.model;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nullable;
+
+import org.starchartlabs.alloy.core.MoreObjects;
+import org.starchartlabs.alloy.core.Preconditions;
+
+/**
+ * Represents a single line with a dependency constraint specification line
+ *
+ * <p>
+ * Lines consist of a constraint to apply (group:artifact:version), and optionally one or more Gradle configuration
+ * names to limit the constraint to. If no configurations are specified, the constraint applies to all configurations
+ *
+ * @author romeara
+ * @since 0.2.0
+ */
+public class Constraint {
+
+    private final String gav;
+
+    private final Set<String> configurations;
+
+    /**
+     * @param line
+     *            Single line from a constraint file to convert to a specification
+     * @since 0.2.0
+     */
+    public Constraint(String line) {
+        Objects.requireNonNull(line);
+
+        List<String> elements = Arrays.asList(line.split(","));
+
+        Preconditions.checkArgument(!elements.isEmpty(), "Empty constraint line provided");
+
+        this.gav = elements.get(0);
+        this.configurations = elements.stream()
+                .skip(1)
+                .collect(Collectors.toSet());
+    }
+
+    /**
+     * @return The group/artifact/version constraint represented in the line
+     * @since 0.2.0
+     */
+    public String getGav() {
+        return gav;
+    }
+
+    /**
+     * @return The specific configurations to apply the constraint to. Empty if the constraint should be applied to all
+     *         configurations
+     * @since 0.2.0
+     */
+    public Set<String> getConfigurations() {
+        return configurations;
+    }
+
+    /**
+     * @param configuration
+     *            The name of a Gradle configuration
+     * @return True if the constraint represented applies to the provided configuration, false otherwise
+     * @since 0.2.0
+     */
+    public boolean isConfigurationApplicable(String configuration) {
+        Objects.requireNonNull(configuration);
+
+        return (configurations.isEmpty() || configurations.contains(configuration));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getGav(),
+                getConfigurations());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof Constraint) {
+            Constraint compare = (Constraint) obj;
+
+            result = Objects.equals(compare.getGav(), getGav())
+                    && Objects.equals(compare.getConfigurations(), getConfigurations());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("gav", getGav())
+                .add("configurations", getConfigurations())
+                .toString();
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ConstraintFileTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ConstraintFileTest.java
@@ -24,6 +24,22 @@ public class ConstraintFileTest {
         new ConstraintFile(null);
     }
 
+    @Test(expectedExceptions = NullPointerException.class)
+    public void getDependencyNotationsNullConfiguration() throws Exception {
+        List<String> lines = new ArrayList<>();
+        lines.add("group1:artifact1:1.0");
+        lines.add("group2:artifact2:2.0");
+        lines.add("group3:artifact3:3.0");
+
+        Path path = Files.createTempFile("constraintFileTest", "no-discards");
+
+        Files.write(path, lines);
+
+        ConstraintFile file = new ConstraintFile(path);
+
+        file.getDependencyNotations(null);
+    }
+
     @Test
     public void getDependencyNotationsNoDiscardedLines() throws Exception {
         List<String> lines = new ArrayList<>();
@@ -37,7 +53,7 @@ public class ConstraintFileTest {
 
         ConstraintFile file = new ConstraintFile(path);
 
-        Set<String> result = file.getDependencyNotations();
+        Set<String> result = file.getDependencyNotations("compile");
 
         Assert.assertNotNull(result);
         Assert.assertEquals(result.size(), 3);
@@ -62,8 +78,32 @@ public class ConstraintFileTest {
 
         ConstraintFile file = new ConstraintFile(path);
 
-        Set<String> result = file.getDependencyNotations();
+        Set<String> result = file.getDependencyNotations("compile");
 
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.size(), 3);
+        Assert.assertTrue(result.contains("group1:artifact1:1.0"));
+        Assert.assertTrue(result.contains("group2:artifact2:2.0"));
+        Assert.assertTrue(result.contains("group3:artifact3:3.0"));
+    }
+
+    @Test
+    public void getDependencyNotationsSpecificConfigurations() throws Exception {
+        List<String> lines = new ArrayList<>();
+        lines.add("group1:artifact1:1.0,first");
+        lines.add("group2:artifact2:2.0,first, second");
+        lines.add("group3:artifact3:3.0");
+        lines.add("group4:artifact3:4.0,third");
+
+        Path path = Files.createTempFile("constraintFileTest", "no-discards");
+
+        Files.write(path, lines);
+
+        ConstraintFile file = new ConstraintFile(path);
+
+        Set<String> result = file.getDependencyNotations("first");
+
+        // Should contain first-only, first & second, and unspecified (all)
         Assert.assertNotNull(result);
         Assert.assertEquals(result.size(), 3);
         Assert.assertTrue(result.contains("group1:artifact1:1.0"));

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/ConstraintTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/ConstraintTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.model;
+
+import org.starchartlabs.flare.plugins.model.Constraint;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ConstraintTest {
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void constructNullLine() throws Exception {
+        new Constraint(null);
+    }
+
+    @Test
+    public void constructNoSpecificConfigurations() throws Exception {
+        Constraint result = new Constraint("group:artifact:1.0");
+
+        Assert.assertEquals(result.getGav(), "group:artifact:1.0");
+        Assert.assertTrue(result.getConfigurations().isEmpty());
+        Assert.assertTrue(result.isConfigurationApplicable("anything"));
+    }
+
+    @Test
+    public void constructSingleConfiguration() throws Exception {
+        Constraint result = new Constraint("group:artifact:1.0,config1");
+
+        Assert.assertEquals(result.getGav(), "group:artifact:1.0");
+        Assert.assertEquals(result.getConfigurations().size(), 1);
+        Assert.assertTrue(result.getConfigurations().contains("config1"));
+        Assert.assertTrue(result.isConfigurationApplicable("config1"));
+        Assert.assertFalse(result.isConfigurationApplicable("other"));
+    }
+
+    @Test
+    public void constructMultipleConfigurations() throws Exception {
+        Constraint result = new Constraint("group:artifact:1.0,config1,config2");
+
+        Assert.assertEquals(result.getGav(), "group:artifact:1.0");
+        Assert.assertEquals(result.getConfigurations().size(), 2);
+        Assert.assertTrue(result.getConfigurations().contains("config1"));
+        Assert.assertTrue(result.getConfigurations().contains("config2"));
+        Assert.assertTrue(result.isConfigurationApplicable("config1"));
+        Assert.assertTrue(result.isConfigurationApplicable("config2"));
+        Assert.assertFalse(result.isConfigurationApplicable("other"));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/model/DependencyConstraintsTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/model/DependencyConstraintsTest.java
@@ -106,7 +106,7 @@ public class DependencyConstraintsTest {
 
         Mockito.verify(project, Mockito.times(3)).getDependencies();
         Mockito.verify(dependencyHandler, Mockito.times(3)).getConstraints();
-        Mockito.verify(configuration, Mockito.times(3)).getName();
+        Mockito.verify(configuration, Mockito.times(4)).getName();
         Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group1:artifact1:1.0");
         Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group2:artifact2:2.0");
         Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group3:artifact3:3.0");
@@ -164,7 +164,7 @@ public class DependencyConstraintsTest {
 
         Mockito.verify(project, Mockito.times(3)).getDependencies();
         Mockito.verify(dependencyHandler, Mockito.times(3)).getConstraints();
-        Mockito.verify(configuration, Mockito.times(3)).getName();
+        Mockito.verify(configuration, Mockito.times(4)).getName();
         Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group1:artifact1:1.0");
         Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group2:artifact2:2.0");
         Mockito.verify(logger).info("Applied {} dependency constraint: {}", configuration, "group3:artifact3:3.0");


### PR DESCRIPTION
Previously, constraints from a dependency constraints file were
unconditionally applied to all configurations. This could lead to
test-only constraints leaking into published documents, such as the
dependencyManagement section of Maven POMs.

This change adds the ability to restrict the configuration(s) a
constraint is applied to from within the dependency constraint file,
which allows clients to determine how broadly they wish each constraint
to be applied