### PR TITLE
GH-23 Fix issue where stale dependency cache could be used across builds

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 - Started allowing limitation of the configurations dependency constraints are applied to via the constraint file specification
+- (GH-23) Change caching logic for loaded dependency information to include time modified, to prevent stale cached content caused by the Gradle Daemon re-using class loaders between builds
 
 ## [0.1.0]
 ### Added


### PR DESCRIPTION
Change caching logic for loaded dependency information to include time
modified, to prevent stale cached content from being used when changes
are made between builds. This situation could arise due to the Gradle
Daemon re-using class loaders between builds