### PR TITLE
Add bintray-credentials plug-in to read key(s) from the environment

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Added
+- bintray-credentials plug-in to encapsulate the behavior of reading credentials for Bintray from the environment
+
 ### Changed
 - (GH-35) Added default "blank" credentials so that tasks other than publishing may be run in systems without the environment variables set
 - Update to Jackson Databind 2.9.10 to address security vulnerabilities

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Individual plug-ins used to apply these behaviors:
 - org.starchartlabs.flare.dependency-constraints
 - org.starchartlabs.flare.increased-test-logging
 - org.starchartlabs.flare.managed-credentials
+- org.starchartlabs.flare.bintray-credentials
 - org.starchartlabs.flare.merge-coverage-reports
 - org.starchartlabs.flare.source-jars
 - org.starchartlabs.flare.metadata-base

--- a/build.gradle
+++ b/build.gradle
@@ -45,6 +45,10 @@ dependencies {
 
 // Setup default test behavior, including failure logging
 test {
+    //This is so tests run in altered environments behave consistently with IDE results, and cannot be used to test credential environment variable behavior
+    environment "BINTRAY_USER", ""
+    environment "BINTRAY_API_KEY", ""
+    
     useTestNG() { 
         useDefaultListeners = true 
     }
@@ -157,6 +161,12 @@ gradlePlugin {
             displayName = 'Managed Credentials'
             description = 'Provides a configurable DSL for defining sets of credentials used within the Gradle build'
             implementationClass = 'org.starchartlabs.flare.plugins.plugin.ManagedCredentialsPlugin'
+        }
+        managedCredentialsPlugin {
+            id = 'org.starchartlabs.flare.bintray-credentials'
+            displayName = 'Bintray Credentials'
+            description = 'Provides setup for bintray credentials to be read from environment variable for use within a Gradle build'
+            implementationClass = 'org.starchartlabs.flare.plugins.plugin.BintrayCredentialsPlugin'
         }
         mergeCoverageReportsPlugin {
             id = 'org.starchartlabs.flare.merge-coverage-reports'

--- a/docs/PLUGINS.md
+++ b/docs/PLUGINS.md
@@ -74,6 +74,14 @@ credentials {
 
 Created credentials may be reference via `${credentials.name1.username}` and `${credentials.name1.password}`
 
+## org.starchartlabs.flare.bintray-credentials
+
+The bintray-credentials plug-in adds a convention on top of the managed-credentials configuration DSL to read bintray user and API key information from the `BINTRAY_USER` and `BINTRAY_API_KEY` environment variables. If unset, these values default to blank.
+
+### Use
+
+Created credentials may be reference via `${credentials.bintray.username}` and `${credentials.bintray.password}`
+
 ## org.starchartlabs.flare.merge-coverage-reports
 
 The merge-coverage-reports plug-in adds a task which generates a single XML Jacoco report which includes coverage information from reports in all sub-modules. The added task (`mergeCoverageReports`), depends on the `test` tasks of all sub-modules, and is added as a dependency of the `check` task of the root project

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/BintrayCredentialsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/BintrayCredentialsPlugin.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.plugin;
+
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.starchartlabs.flare.plugins.model.CredentialSet;
+
+/**
+ * Configuration plug-in that adds default configuration to read credentials from environment variables BINTRAY_USER and
+ * BINTRAY_API_KEY for use within the Gradle build
+ *
+ * @author romeara
+ * @since 1.0.0
+ */
+public class BintrayCredentialsPlugin implements Plugin<Project> {
+
+    @Override
+    public void apply(Project project) {
+        project.getPluginManager().apply("org.starchartlabs.flare.managed-credentials");
+
+        @SuppressWarnings("unchecked")
+        NamedDomainObjectContainer<CredentialSet> credentials = (NamedDomainObjectContainer<CredentialSet>) project
+        .getExtensions().getByName("credentials");
+
+        // Setup reading BinTray credentials from the environment, with defaults of blank to allow non-publishing
+        // tasks to be run in environments where the environment variables are not set
+        credentials.add(new CredentialSet("bintray")
+                .environment("BINTRAY_USER", "BINTRAY_API_KEY")
+                .defaultCredentials("", ""));
+    }
+
+}

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
@@ -8,10 +8,8 @@ package org.starchartlabs.flare.plugins.plugin;
 
 import java.io.File;
 
-import org.gradle.api.NamedDomainObjectContainer;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.starchartlabs.flare.plugins.model.CredentialSet;
 import org.starchartlabs.flare.plugins.model.DependencyConstraints;
 import org.starchartlabs.flare.plugins.model.ProjectMetaData;
 
@@ -35,6 +33,7 @@ public class MultiModuleLibraryPlugin implements Plugin<Project> {
             p.getPluginManager().apply("org.starchartlabs.flare.source-jars");
             p.getPluginManager().apply("org.starchartlabs.flare.metadata-base");
             p.getPluginManager().apply("org.starchartlabs.flare.metadata-pom");
+            p.getPluginManager().apply("org.starchartlabs.flare.bintray-credentials");
 
             DependencyConstraints dependencyConstraints = p.getExtensions().getByType(DependencyConstraints.class);
             ProjectMetaData projectMetaData = p.getExtensions().getByType(ProjectMetaData.class);
@@ -54,16 +53,6 @@ public class MultiModuleLibraryPlugin implements Plugin<Project> {
             if (contributorsFile.exists()) {
                 projectMetaData.github(gh -> gh.contributors(contributorsFile));
             }
-
-            @SuppressWarnings("unchecked")
-            NamedDomainObjectContainer<CredentialSet> credentials = (NamedDomainObjectContainer<CredentialSet>) p
-            .getExtensions().getByName("credentials");
-
-            // Setup reading BinTray credentials from the environment, with defaults of blank to allow non-publishing
-            // tasks to be run in environments where the environment variables are not set
-            credentials.add(new CredentialSet("bintray")
-                    .environment("BINTRAY_USER", "BINTRAY_API_KEY")
-                    .defaultCredentials("", ""));
 
         });
     }

--- a/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.bintray-credentials.properties
+++ b/src/main/resources/META-INF/gradle-plugins/org.starchartlabs.flare.bintray-credentials.properties
@@ -1,0 +1,1 @@
+implementation-class=org.starchartlabs.flare.plugins.plugin.BintrayCredentialsPlugin

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginIntegrationTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.gradle.testkit.runner.BuildResult;
+import org.gradle.testkit.runner.GradleRunner;
+import org.gradle.testkit.runner.TaskOutcome;
+import org.starchartlabs.flare.plugins.test.IntegrationTestListener;
+import org.starchartlabs.flare.plugins.test.TestGradleProject;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Listeners;
+import org.testng.annotations.Test;
+
+@Listeners(value = { IntegrationTestListener.class })
+public class BintrayCredentialsPluginIntegrationTest {
+
+    private static final Path BUILD_FILE_DIRECTORY = Paths.get("org", "starchartlabs", "flare", "plugins", "test",
+            "bintray", "credentials");
+
+    private static final Path BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("build.gradle");
+
+    private Path projectPath;
+
+    @BeforeClass
+    public void setup() throws Exception {
+        projectPath = TestGradleProject.builder(BUILD_FILE)
+                .build()
+                .getProjectDirectory();
+    }
+
+    // TODO romeara Try to figure out a way to test the environment variable scenario
+
+    // Defaults to blank
+    @Test
+    public void defaultCredentials() throws Exception {
+        String expectedUsername = "";
+        String expectedPassword = "";
+
+        BuildResult result = GradleRunner.create()
+                .withPluginClasspath()
+                .withProjectDir(projectPath.toFile())
+                .withArguments("credentialsPrintout")
+                .withGradleVersion("5.0")
+                .build();
+
+        Assert.assertTrue(result.getOutput().contains(expectedUsername + ":" + expectedPassword));
+
+        TaskOutcome outcome = result.task(":credentialsPrintout").getOutcome();
+        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 StarChart-Labs@github.com Authors
+ *
+ * This software may be modified and distributed under the terms
+ * of the MIT license. See the LICENSE file for details.
+ */
+package org.starchartlabs.flare.plugins.test.plugin;
+
+import org.gradle.api.NamedDomainObjectContainer;
+import org.gradle.api.Project;
+import org.gradle.testfixtures.ProjectBuilder;
+import org.starchartlabs.flare.plugins.model.CredentialSet;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+public class BintrayCredentialsPluginTest {
+
+    private static final String PLUGIN_ID = "org.starchartlabs.flare.bintray-credentials";
+
+    private Project project;
+
+    @BeforeClass
+    public void setupProject() {
+        project = ProjectBuilder.builder().build();
+        project.getPluginManager().apply(PLUGIN_ID);
+        project.getPluginManager().apply("org.starchartlabs.flare.managed-credentials");
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void configurationApplied() throws Exception {
+        NamedDomainObjectContainer<CredentialSet> found = (NamedDomainObjectContainer<CredentialSet>) project
+                .getExtensions().getByName("credentials");
+
+        found.getByName("bintray");
+
+        Assert.assertNotNull(found);
+
+        CredentialSet bintray = found.getByName("bintray");
+
+        // Bintray defaults to blank in an environment with the proper ENV set
+        Assert.assertNotNull(bintray);
+        Assert.assertEquals(bintray.getUsername(), "");
+        Assert.assertEquals(bintray.getPassword(), "");
+    }
+
+}

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
@@ -135,7 +135,7 @@ public class MultiModuleLibraryPluginIntegrationTest {
     }
 
     @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
-    public void singleProjectManagedCredentials() throws Exception {
+    public void singleProjectBintrayCredentials() throws Exception {
         String expectedLine = "Credentials configured: bintray";
 
         Assert.assertTrue(singleProjectBuildResult.getOutput().contains(expectedLine),
@@ -269,7 +269,7 @@ public class MultiModuleLibraryPluginIntegrationTest {
     }
 
     @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })
-    public void multiModuleProjectManagedCredentials() throws Exception {
+    public void multiModuleProjectBintrayCredentials() throws Exception {
         String expectedLine = "Credentials configured: bintray";
 
         Assert.assertTrue(multiModuleProjectBuildResult.getOutput().contains(expectedLine),

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/bintray/credentials/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/bintray/credentials/build.gradle
@@ -1,0 +1,9 @@
+plugins {
+    id  'org.starchartlabs.flare.bintray-credentials'
+}
+
+task credentialsPrintout {
+    doLast{
+        project.logger.lifecycle("${credentials.bintray.username}:${credentials.bintray.password}")
+    }
+}


### PR DESCRIPTION
Encapsulate the multi-module-library behavior of setting up Bintray
credentials read from the environment into an independent plug-in. This
allows any additional logic associated with this configuration to be
encapsulated in a specific place