### PR TITLE
Resolves GH-36: Adds defaults for POM name/description

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - (GH-35) Added default "blank" credentials so that tasks other than publishing may be run in systems without the environment variables set
 - (GH-15) Changed multi-module-library plug-in to only add default bintray credential set if the `com.jfrog.bintray` plug-in is applied
+- (GH-36) Add default POM values for name and description as part of the metadata-pom plug-in
 - Update to Jackson Databind 2.9.10 to address security vulnerabilities
 
 ## [0.2.1]

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataPomPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MetaDataPomPlugin.java
@@ -36,6 +36,12 @@ public class MetaDataPomPlugin implements Plugin<Project> {
                 PublishingExtension publishing = project.getExtensions().getByType(PublishingExtension.class);
 
                 publishing.getPublications().withType(MavenPublication.class).all(publication -> {
+                    // Apply default name/description
+                    publication.pom(pom -> {
+                        pom.getName().set(project.getName());
+                        pom.getDescription().set(project.getDescription());
+                    });
+
                     publication.pom(projectMetaData.getPomConfiguration());
                 });
             });

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataPomPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MetaDataPomPluginIntegrationTest.java
@@ -66,7 +66,8 @@ public class MetaDataPomPluginIntegrationTest {
         List<PomLicense> licenses = Collections
                 .singletonList(new PomLicense("license/name", "license/url", "license/distribution"));
 
-        PomProject expectedProject = new PomProject("http://url", scm, developers, contributors, licenses);
+        PomProject expectedProject = new PomProject(standardSetupProjectPath.getFileName().toString(), "description",
+                "http://url", scm, developers, contributors, licenses);
 
         validatePom(standardSetupProjectPath, "maven", expectedProject);
     }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
@@ -247,7 +247,8 @@ public class MultiModuleLibraryPluginIntegrationTest {
                 new PomLicense("Eclipse Public License 1.0", "https://opensource.org/licenses/EPL-1.0",
                         "epl/distribution"));
 
-        PomProject expectedProject = new PomProject("http://url", scm, developers, contributors, licenses);
+        PomProject expectedProject = new PomProject(singleProjectPath.getFileName().toString(), "description",
+                "http://url", scm, developers, contributors, licenses);
 
         validatePom(singleProjectPath, "maven", expectedProject);
     }
@@ -372,7 +373,8 @@ public class MultiModuleLibraryPluginIntegrationTest {
                 new PomLicense("Eclipse Public License 1.0", "https://opensource.org/licenses/EPL-1.0",
                         "epl/distribution"));
 
-        PomProject expectedProject = new PomProject("http://url", scm, developers, contributors, licenses);
+        PomProject expectedProject = new PomProject(singleProjectNoExternalPath.getFileName().toString(), "description",
+                "http://url", scm, developers, contributors, licenses);
 
         validatePom(singleProjectNoExternalPath, "maven", expectedProject);
     }
@@ -511,8 +513,8 @@ public class MultiModuleLibraryPluginIntegrationTest {
             List<PomLicense> licenses = Arrays.asList(
                     new PomLicense("The MIT License", "https://opensource.org/licenses/MIT", "repo"));
 
-            PomProject expectedProject = new PomProject("https://github.com/owner/" + subProjectName, scm, developers,
-                    contributors, licenses);
+            PomProject expectedProject = new PomProject(subProjectName, "description",
+                    "https://github.com/owner/" + subProjectName, scm, developers, contributors, licenses);
 
             validatePom(multiModuleProjectPath.resolve(subProjectName), "maven", expectedProject);
         }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomProject.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/pom/PomProject.java
@@ -18,6 +18,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class PomProject {
 
+    private String name;
+
+    private String description;
+
     private String url;
 
     private PomScm scm;
@@ -32,13 +36,32 @@ public class PomProject {
 
     }
 
-    public PomProject(String url, PomScm scm, List<PomDeveloper> developers, List<PomContributor> contributors,
-            List<PomLicense> licenses) {
+    public PomProject(String name, String description, String url, PomScm scm, List<PomDeveloper> developers,
+            List<PomContributor> contributors, List<PomLicense> licenses) {
+        this.name = name;
+        this.description = description;
         this.url = url;
         this.scm = scm;
         this.developers = developers;
         this.contributors = contributors;
         this.licenses = licenses;
+    }
+
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
     }
 
     public String getUrl() {
@@ -83,7 +106,9 @@ public class PomProject {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getUrl(),
+        return Objects.hash(getName(),
+                getDescription(),
+                getUrl(),
                 getScm(),
                 getDevelopers(),
                 getContributors(),
@@ -97,7 +122,9 @@ public class PomProject {
         if (obj instanceof PomProject) {
             PomProject compare = (PomProject) obj;
 
-            result = Objects.equals(compare.getUrl(), getUrl())
+            result = Objects.equals(compare.getName(), getName())
+                    && Objects.equals(compare.getDescription(), getDescription())
+                    && Objects.equals(compare.getUrl(), getUrl())
                     && Objects.equals(compare.getScm(), getScm())
                     && Objects.equals(compare.getDevelopers(), getDevelopers())
                     && Objects.equals(compare.getContributors(), getContributors())
@@ -110,6 +137,8 @@ public class PomProject {
     @Override
     public String toString() {
         return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("name", getName())
+                .add("description", getDescription())
                 .add("url", getUrl())
                 .add("scm", getScm())
                 .add("developers", getDevelopers())

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/pom/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/metadata/pom/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'maven-publish'
 }
 
+description = "description"
+
 projectMetaData{
     url = 'http://url'
     

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
@@ -6,6 +6,8 @@ plugins {
     id 'com.jfrog.bintray' version '1.8.4'
 }
 
+description = "description"
+
 projectMetaData{
     url = 'http://url'
     

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectNoExternalBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectNoExternalBuild.gradle
@@ -5,6 +5,8 @@ plugins {
     id 'maven-publish'
 }
 
+description = "description"
+
 projectMetaData{
     url = 'http://url'
     

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'maven-publish'
 }
 
+description = "description"
+
 projectMetaData{
     github {
         repository 'owner', "${project.name}"


### PR DESCRIPTION
Setup MavenPublication pom values from project name/description as part
of the metadata-pom plug-in