### PR TITLE
Switch CodeCov to actions methodology

### DIFF
--- a/.github/workflows/continous_integration.yml
+++ b/.github/workflows/continous_integration.yml
@@ -15,6 +15,10 @@ jobs:
         java-version: 1.8
     - name: Build with Gradle
       run: ./gradlew build
+    - name: CodeCov
+      uses: codecov/codecov-action@v1.0.2
+      with:
+        token: ${{secrets.CODECOV_UPLOAD_TOKEN}}
     - name: Upload to CoPilot
       if: github.event_name == 'push' || github.event_name == 'pull_request'
       run: bash <(curl -s https://copilot.blackducksoftware.com/ci/githubactions/scripts/upload)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: java
 jdk:
   - openjdk8
   
-after_success:
-  - bash <(curl -s https://codecov.io/bash)
-  
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Move CodeCov upload to actions. This required additional external setup
of a "secret" in GitHub settings for the repository - the key
CODECOV_UPLOAD_TOKEN as given a valid provided by settings on codecov.io
which is unique per repository