### PR TITLE
Reverts GH-41: Remove Bintray dependency from production

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -12,7 +12,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - (GH-35) Added default "blank" credentials so that tasks other than publishing may be run in systems without the environment variables set
 - (GH-15) Changed multi-module-library plug-in to only add default bintray credential set if the `com.jfrog.bintray` plug-in is applied
 - (GH-36) Add default POM values for name and description as part of the metadata-pom plug-in
-- (GH-41) Add automatic application of configured bintray values to bintray extension via `bintray-credentials` plug-in
 - Update to Jackson Databind 2.9.10 to address security vulnerabilities
 
 ## [0.2.1]

--- a/build.gradle
+++ b/build.gradle
@@ -36,13 +36,14 @@ configurations.all {
 
 dependencies { 
     compile gradleApi()
-    compile 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
     compile 'org.starchartlabs.alloy:alloy-core:0.5.0'
     
     testCompile gradleTestKit()
     testCompile 'com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.10.1'
     testCompile 'org.mockito:mockito-core:2.25.0'
     testCompile 'org.testng:testng:6.14.3'
+    
+    testRuntime 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
 }
 
 // Setup default test behavior, including failure logging

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/BintrayCredentialsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/BintrayCredentialsPlugin.java
@@ -11,8 +11,6 @@ import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.starchartlabs.flare.plugins.model.CredentialSet;
 
-import com.jfrog.bintray.gradle.BintrayExtension;
-
 /**
  * Configuration plug-in that adds default configuration to read credentials from environment variables BINTRAY_USER and
  * BINTRAY_API_KEY for use within the Gradle build
@@ -25,9 +23,7 @@ public class BintrayCredentialsPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getPluginManager().withPlugin("com.jfrog.bintray", bintrayPlugin -> {
-            CredentialSet credentials = setupManagedCredentials(project);
-
-            configureBintrayExtension(project, credentials);
+            setupManagedCredentials(project);
         });
     }
 
@@ -47,13 +43,6 @@ public class BintrayCredentialsPlugin implements Plugin<Project> {
         credentials.add(result);
 
         return result;
-    }
-
-    private void configureBintrayExtension(Project project, CredentialSet credentials) {
-        BintrayExtension bintray = project.getExtensions().getByType(BintrayExtension.class);
-
-        bintray.setUser(credentials.getUsername());
-        bintray.setKey(credentials.getPassword());
     }
 
 }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginIntegrationTest.java
@@ -40,7 +40,7 @@ public class BintrayCredentialsPluginIntegrationTest {
         buildResult = GradleRunner.create()
                 .withPluginClasspath()
                 .withProjectDir(projectPath.toFile())
-                .withArguments("credentialsPrintout", "extensionPrintout")
+                .withArguments("credentialsPrintout")
                 .withGradleVersion("5.0")
                 .build();
     }
@@ -56,17 +56,6 @@ public class BintrayCredentialsPluginIntegrationTest {
         Assert.assertTrue(buildResult.getOutput().contains(expectedUsername + ":" + expectedPassword));
 
         TaskOutcome outcome = buildResult.task(":credentialsPrintout").getOutcome();
-        Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
-    }
-
-    @Test
-    public void extensionCredentials() throws Exception {
-        String expectedUsername = "";
-        String expectedPassword = "";
-
-        Assert.assertTrue(buildResult.getOutput().contains("u" + expectedUsername + ":k" + expectedPassword));
-
-        TaskOutcome outcome = buildResult.task(":extensionPrintout").getOutcome();
         Assert.assertTrue(TaskOutcome.SUCCESS.equals(outcome));
     }
 

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/BintrayCredentialsPluginTest.java
@@ -14,8 +14,6 @@ import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.jfrog.bintray.gradle.BintrayExtension;
-
 public class BintrayCredentialsPluginTest {
 
     private static final String PLUGIN_ID = "org.starchartlabs.flare.bintray-credentials";
@@ -46,16 +44,6 @@ public class BintrayCredentialsPluginTest {
         Assert.assertNotNull(bintray);
         Assert.assertEquals(bintray.getUsername(), "");
         Assert.assertEquals(bintray.getPassword(), "");
-    }
-
-    @Test
-    public void bintrayConfigurationApplied() throws Exception {
-        BintrayExtension found = project.getExtensions().getByType(BintrayExtension.class);
-
-        Assert.assertNotNull(found);
-
-        Assert.assertEquals(found.getUser(), "");
-        Assert.assertEquals(found.getKey(), "");
     }
 
 }

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
@@ -160,14 +160,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
     }
 
     @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
-    public void singleProjectBintrayExtensionCredentials() throws Exception {
-        String expectedLine = "Bintray Credentials: u:k";
-
-        Assert.assertTrue(singleProjectBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
-    }
-
-    @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
     public void singleProjectBintrayCredentials() throws Exception {
         String expectedLine = "Credentials configured: bintray";
 
@@ -426,14 +418,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
             Assert.assertTrue(multiModuleProjectBuildResult.getOutput().contains(expectedLine),
                     Strings.format("Did not find expected line '%s'", expectedLine));
         }
-    }
-
-    @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })
-    public void multiModuleProjectBintrayExtensionCredentials() throws Exception {
-        String expectedLine = "Bintray Credentials: u:k";
-
-        Assert.assertTrue(multiModuleProjectBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
     }
 
     @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/bintray/credentials/build.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/bintray/credentials/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'com.jfrog.bintray' version '1,8,4'
+    id 'com.jfrog.bintray' version '1.8.4'
     
     id 'org.starchartlabs.flare.bintray-credentials'
 }
@@ -7,11 +7,5 @@ plugins {
 task credentialsPrintout {
     doLast{
         project.logger.lifecycle("${credentials.bintray.username}:${credentials.bintray.password}")
-    }
-}
-
-task extensionPrintout {
-    doLast{
-        project.logger.lifecycle("u${bintray.user}:k${bintray.key}")
     }
 }

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/rootProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/rootProjectBuild.gradle
@@ -10,9 +10,6 @@ allprojects{
 }
 
 task outputManagedCredentials{
-    doFirst {
-        project.logger.lifecycle("Bintray Credentials: u${bintray.user}:k${bintray.key}")
-    }
     doLast{
         credentials.all{
             project.logger.lifecycle("Credentials configured: ${it.name}")

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
@@ -60,9 +60,6 @@ repositories {
 }
 
 task outputManagedCredentials{
-    doFirst {
-        project.logger.lifecycle("Bintray Credentials: u${bintray.user}:k${bintray.key}")
-    }
     doLast{
         credentials.all{
             project.logger.lifecycle("Credentials configured: ${it.name}")


### PR DESCRIPTION
The Bintray plug-in depends on very old libraries, exposing consumers to
increased risk - remove its use until a more through evaluation of the
plug-in can be completed for a future release