### PR TITLE
Update to deprecate BinTray and dependency constraint plug-ins

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+### Changed
+- Removed `org.starchartlabs.flare.dependency-constraints` from multi-module library plug-in
+- Removed `org.starchartlabs.flare.bintray-credentials` from multi-module library plug-in
+- Deprecated `org.starchartlabs.flare.dependency-constraints` plug-in in favor of Gradle platform configuration
+- Deprecated `org.starchartlabs.flare.bintray-credentials` as BinTray has been sunset
+
 ## [1.0.0]
 ### Added
 - bintray-credentials plug-in to encapsulate the behavior of reading credentials for Bintray from the environment

--- a/README.md
+++ b/README.md
@@ -39,8 +39,6 @@ The `multi-module-library` convention is intended for gradle projects which defi
 Applying this convention has the following effects:
 
 - Applies a task to the root project which will create a merged Jacoco XML report in `${rootProject.buildDir}/reports/jacoco/report.xml`
-- Reads dependency versions from file `"${rootDir}/dependencies.properties"` and applies these as dependency constraints
-  - This file may have empty lines, lines starting with `#` which act as comments, or lines of the form `group:artifact:version[,configurations,...]`
 - Add a reference to credentials read from environment variables `BINTRAY_USER` and `BINTRAY_API_KEY`. These variables must be defined if the credentials are used, otherwise they default to blank
   - These credentials can be referenced by `${credentials.bintray.username}` and `${credentials.bintray.password}`
 - Configures the `user` and `key` values of the `bintray` extension from the configured credentials
@@ -53,7 +51,6 @@ Applying this convention has the following effects:
 
 Individual plug-ins used to apply these behaviors:
 
-- org.starchartlabs.flare.dependency-constraints
 - org.starchartlabs.flare.increased-test-logging
 - org.starchartlabs.flare.managed-credentials
 - org.starchartlabs.flare.bintray-credentials

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Application Versions
-version=1.0.1-SNAPSHOT
+version=2.0.0-SNAPSHOT
 
 # Consumed Language/Build System Versions
 sourceCompatibility=1.8

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/BintrayCredentialsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/BintrayCredentialsPlugin.java
@@ -25,6 +25,8 @@ public class BintrayCredentialsPlugin implements Plugin<Project> {
         project.getPluginManager().withPlugin("com.jfrog.bintray", bintrayPlugin -> {
             setupManagedCredentials(project);
         });
+
+        project.getLogger().warn("Flare BinTray plug-in is deprecated - BinTray no longer exists");
     }
 
     private CredentialSet setupManagedCredentials(Project project) {
@@ -32,7 +34,7 @@ public class BintrayCredentialsPlugin implements Plugin<Project> {
 
         @SuppressWarnings("unchecked")
         NamedDomainObjectContainer<CredentialSet> credentials = (NamedDomainObjectContainer<CredentialSet>) project
-        .getExtensions().getByName("credentials");
+                .getExtensions().getByName("credentials");
 
         // Setup reading BinTray credentials from the environment, with defaults of blank to allow non-publishing
         // tasks to be run in environments where the environment variables are not set

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/DependencyConstraintsPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/DependencyConstraintsPlugin.java
@@ -24,6 +24,9 @@ public class DependencyConstraintsPlugin implements Plugin<Project> {
     @Override
     public void apply(Project project) {
         project.getExtensions().add(CONSTRAINTS_DSL_EXTENSION, new DependencyConstraints(project));
+
+        project.getLogger()
+                .warn("Flare dependency management plug-in is deprecated - use Gradle platform constraints instead");
     }
 
 }

--- a/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
+++ b/src/main/java/org/starchartlabs/flare/plugins/plugin/MultiModuleLibraryPlugin.java
@@ -10,7 +10,6 @@ import java.io.File;
 
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
-import org.starchartlabs.flare.plugins.model.DependencyConstraints;
 import org.starchartlabs.flare.plugins.model.ProjectMetaData;
 
 /**
@@ -27,27 +26,16 @@ public class MultiModuleLibraryPlugin implements Plugin<Project> {
         project.getPluginManager().apply("org.starchartlabs.flare.merge-coverage-reports");
 
         project.allprojects(p -> {
-            p.getPluginManager().apply("org.starchartlabs.flare.dependency-constraints");
             p.getPluginManager().apply("org.starchartlabs.flare.managed-credentials");
             p.getPluginManager().apply("org.starchartlabs.flare.increased-test-logging");
             p.getPluginManager().apply("org.starchartlabs.flare.source-jars");
             p.getPluginManager().apply("org.starchartlabs.flare.metadata-base");
             p.getPluginManager().apply("org.starchartlabs.flare.metadata-pom");
 
-            p.getPluginManager().withPlugin("com.jfrog.bintray", bintrayPlugin -> {
-                p.getPluginManager().apply("org.starchartlabs.flare.bintray-credentials");
-            });
-
-            DependencyConstraints dependencyConstraints = p.getExtensions().getByType(DependencyConstraints.class);
             ProjectMetaData projectMetaData = p.getExtensions().getByType(ProjectMetaData.class);
 
-            File dependenciesFile = project.file(project.getProjectDir().toPath().resolve("dependencies.properties"));
             File developersFile = project.file(project.getProjectDir().toPath().resolve("developers.properties"));
             File contributorsFile = project.file(project.getProjectDir().toPath().resolve("contributors.properties"));
-
-            if (dependenciesFile.exists()) {
-                dependencyConstraints.file(dependenciesFile);
-            }
 
             if (developersFile.exists()) {
                 projectMetaData.github(gh -> gh.developers(developersFile));

--- a/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
+++ b/src/test/java/org/starchartlabs/flare/plugins/test/plugin/MultiModuleLibraryPluginIntegrationTest.java
@@ -49,8 +49,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
 
     private static final Path SUB_PROJECT_BUILD_FILE = BUILD_FILE_DIRECTORY.resolve("subProjectBuild.gradle");
 
-    private static final Path DEPENDENCIES_FILE = BUILD_FILE_DIRECTORY.resolve("dependencies.properties");
-
     private static final Path DEVELOPERS_FILE = BUILD_FILE_DIRECTORY.resolve("developers.properties");
 
     private static final Path CONTRIBUTORS_FILE = BUILD_FILE_DIRECTORY.resolve("contributors.properties");
@@ -76,7 +74,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
                 .addJavaFile("org.starchartlabs.flare.merge.coverage.reports", "Main")
                 .addTestFile("org.starchartlabs.flare.test.merge.coverage.reports", "MainTest",
                         "org.starchartlabs.flare.merge.coverage.reports.Main")
-                .addFile(DEPENDENCIES_FILE, Paths.get("dependencies.properties"))
                 .build()
                 .getProjectDirectory();
 
@@ -84,12 +81,10 @@ public class MultiModuleLibraryPluginIntegrationTest {
                 .addJavaFile("org.starchartlabs.flare.merge.coverage.reports", "Main")
                 .addTestFile("org.starchartlabs.flare.test.merge.coverage.reports", "MainTest",
                         "org.starchartlabs.flare.merge.coverage.reports.Main")
-                .addFile(DEPENDENCIES_FILE, Paths.get("dependencies.properties"))
                 .build()
                 .getProjectDirectory();
 
         multiModuleProjectPath = TestGradleProject.builder(ROOT_PROJECT_BUILD_FILE)
-                .addFile(DEPENDENCIES_FILE, Paths.get("dependencies.properties"))
                 .addFile(DEVELOPERS_FILE, Paths.get("developers.properties"))
                 .addFile(CONTRIBUTORS_FILE, Paths.get("contributors.properties"))
                 .subProject("one", SUB_PROJECT_BUILD_FILE)
@@ -149,22 +144,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
                         "<class name=\"org/starchartlabs/flare/merge/coverage/reports/Main\" sourcefilename=\"Main.java\">"));
 
         Assert.assertTrue(coveredMainFile, "Coverage report missing line for expected source file");
-    }
-
-    @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
-    public void singleProjectDependencyConstraints() throws Exception {
-        String expectedLine = "Applied configuration ':compile' dependency constraint: org.testng:testng:6.14.3";
-
-        Assert.assertTrue(singleProjectBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
-    }
-
-    @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
-    public void singleProjectBintrayCredentials() throws Exception {
-        String expectedLine = "Credentials configured: bintray";
-
-        Assert.assertTrue(singleProjectBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
     }
 
     @Test(dependsOnMethods = { "singleProjectBuildSuccessful" })
@@ -275,22 +254,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
                         "<class name=\"org/starchartlabs/flare/merge/coverage/reports/Main\" sourcefilename=\"Main.java\">"));
 
         Assert.assertTrue(coveredMainFile, "Coverage report missing line for expected source file");
-    }
-
-    @Test(dependsOnMethods = { "singleProjectNoExternalBuildSuccessful" })
-    public void singleProjectNoExternalDependencyConstraints() throws Exception {
-        String expectedLine = "Applied configuration ':compile' dependency constraint: org.testng:testng:6.14.3";
-
-        Assert.assertTrue(singleProjectNoExternalBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
-    }
-
-    @Test(dependsOnMethods = { "singleProjectNoExternalBuildSuccessful" })
-    public void singleProjecNoExternaltBintrayCredentials() throws Exception {
-        String expectedLine = "Credentials configured: bintray";
-
-        Assert.assertFalse(singleProjectNoExternalBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Found unexpected line '%s'", expectedLine));
     }
 
     @Test(dependsOnMethods = { "singleProjectNoExternalBuildSuccessful" })
@@ -408,27 +371,6 @@ public class MultiModuleLibraryPluginIntegrationTest {
     }
 
     @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })
-    public void multiModuleProjectDependencyContraints() throws Exception {
-        List<String> expectedLines = new ArrayList<>();
-
-        expectedLines.add("Applied configuration ':one:compile' dependency constraint: org.testng:testng:6.14.3");
-        expectedLines.add("Applied configuration ':two:compile' dependency constraint: org.testng:testng:6.14.3");
-
-        for (String expectedLine : expectedLines) {
-            Assert.assertTrue(multiModuleProjectBuildResult.getOutput().contains(expectedLine),
-                    Strings.format("Did not find expected line '%s'", expectedLine));
-        }
-    }
-
-    @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })
-    public void multiModuleProjectBintrayCredentials() throws Exception {
-        String expectedLine = "Credentials configured: bintray";
-
-        Assert.assertTrue(multiModuleProjectBuildResult.getOutput().contains(expectedLine),
-                Strings.format("Did not find expected line '%s'", expectedLine));
-    }
-
-    @Test(dependsOnMethods = { "multiModuleProjectBuildSuccessful" })
     public void multiModuleProjectIncreasedTestLogging() throws Exception {
         List<String> expectedLines = new ArrayList<>();
 
@@ -481,7 +423,7 @@ public class MultiModuleLibraryPluginIntegrationTest {
             expectedLines.add("scm.developerConnection: scm:git:ssh://github.com/owner/" + subProjectName + ".git");
 
             expectedLines
-            .add("developer: dev-file-usernameonly:dev-file-usernameonly:https://github.com/dev-file-usernameonly");
+                    .add("developer: dev-file-usernameonly:dev-file-usernameonly:https://github.com/dev-file-usernameonly");
             expectedLines.add("developer: dev-file-username:dev-file-name:https://github.com/dev-file-username");
 
             expectedLines.add("contributor: contrib-file-usernameonly:https://github.com/contrib-file-usernameonly");

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/dependencies.properties
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/dependencies.properties
@@ -1,2 +1,0 @@
-# Locked version
-org.testng:testng:6.14.3

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/rootProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/rootProjectBuild.gradle
@@ -1,6 +1,5 @@
 plugins {
     id  'org.starchartlabs.flare.multi-module-library'
-    id 'com.jfrog.bintray' version '1.8.4'
 }
 
 allprojects{

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectBuild.gradle
@@ -3,7 +3,6 @@ plugins {
     id 'java'
     id 'jacoco'
     id 'maven-publish'
-    id 'com.jfrog.bintray' version '1.8.4'
 }
 
 description = "description"
@@ -38,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'org.testng:testng'
+    testCompile 'org.testng:testng:6.14.3'
 }
 
 test {

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectNoExternalBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/singleProjectNoExternalBuild.gradle
@@ -37,7 +37,7 @@ repositories {
 }
 
 dependencies {
-    testCompile 'org.testng:testng'
+    testCompile 'org.testng:testng:6.14.3'
 }
 
 test {

--- a/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
+++ b/src/test/resources/org/starchartlabs/flare/plugins/test/multi/module/library/subProjectBuild.gradle
@@ -17,7 +17,7 @@ projectMetaData{
 }
 
 dependencies {
-    testCompile 'org.testng:testng'
+    testCompile 'org.testng:testng:6.14.3'
 }
 
 test {


### PR DESCRIPTION
Deprecate defunct plug-ins, and remove from the default set in the multi-module library. Increment to next major version to indicate loss of backwards compatibility